### PR TITLE
fix(deploy): bundle api/prompts/** so the serverless function can boot

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,8 @@
     "functions": {
         "api/index.py": {
             "maxDuration": 300,
-            "memory": 1024
+            "memory": 1024,
+            "includeFiles": "api/prompts/**"
         }
     },
     "rewrites": [


### PR DESCRIPTION
## Summary

Production was crashing every API endpoint with HTTP 500 (Next.js
fallback page) immediately after deploy. Confirmed by curl:

\`\`\`
GET /api/v1/byok-status   → 500
POST /api/v1/jobs/report  → 500
GET /                      → 200 (Next.js OK, so frontend builds fine)
\`\`\`

## Root cause

Vercel's automatic file tracer can't follow dynamic open() paths like
\`Path(__file__).parent.parent / "prompts" / "system_classifier.txt"\` —
that's how IntentClassifier / MindmapGenerator / NodeExpander /
ReportGenerator each load their system prompt at module-level \`__init__\`.

Result: \`api/prompts/\` was simply missing from the deployed function
bundle, so every classifier instantiation threw \`FileNotFoundError\` at
import time. Because \`api/index.py\` instantiates those at module load,
even trivial handlers like \`/api/v1/byok-status\` crashed before their
function body ran.

## Fix

Add \`includeFiles: "api/prompts/**"\` to the function config in
\`vercel.json\` so the 8 system-prompt \`.txt\` files plus
\`framework_templates.json\` and \`layer_definitions.json\` ride with
the function package. \`includeFiles\` glob is workspace-rooted per
Vercel's spec.

## Test plan

After merge, the production deploy should:
- [ ] \`curl https://<prod>/api/v1/byok-status\` → \`{"has_server_key": …}\`
- [ ] \`curl -X POST https://<prod>/api/v1/jobs/report …\` → 202 + \`{job_id}\`
- [ ] Frontend at \`/\` → unchanged (was already 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)