### PR TITLE
fix(deploy): widen includeFiles to api/** so all sibling modules ship

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
         "api/index.py": {
             "maxDuration": 300,
             "memory": 1024,
-            "includeFiles": "api/prompts/**"
+            "includeFiles": "api/**"
         }
     },
     "rewrites": [


### PR DESCRIPTION
## Summary

Vercel runtime log on the previous deploy:

\`\`\`
500  GET /api/v1/byok-status
       could not import \"api/index.py\": Traceback (most recent call last): File ...
500  POST /api/v1/jobs/report
       could not import \"api/index.py\": Traceback (most recent call last): File ...
\`\`\`

PR #3 fixed the prompt-file bundling but the function still crashed at
**module import**, before any prompt was ever opened. \`api/index.py\` imports
~10 sibling modules (\`logic.*\`, \`schemas.*\`, \`config\`, \`jobs\`); none of
those were included in the function bundle because Vercel only auto-includes
the entrypoint plus what its tracer can prove it needs — and \`includeFiles\`
last time only added \`api/prompts/**\`.

## Fix

Widen the glob:

\`\`\`diff
- \"includeFiles\": \"api/prompts/**\"
+ \"includeFiles\": \"api/**\"
\`\`\`

Covers \`api/logic/**\`, \`api/schemas/**\`, \`api/lib/**\`, \`api/jobs.py\`,
\`api/config.py\`, and \`api/prompts/**\` in one declaration. Source size
under \`api/\` is ~1MB so well within Vercel's per-function budget.

## Test plan

After merge, on the new production URL:
- [ ] \`curl /api/v1/byok-status\` → \`{\"has_server_key\": …}\` (not 500 HTML)
- [ ] \`curl -X POST /api/v1/jobs/report …\` → 202 + \`{job_id}\`
- [ ] Logs show no more \"could not import\" entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)