### PR TITLE
fix(deploy): add sys.path shim so api/index.py finds sibling modules

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -3,6 +3,18 @@ MindBusiness AI Backend - FastAPI Server
 Provides framework classification API for mindmap generation.
 """
 
+# ── Vercel sys.path shim ─────────────────────────────────────────────────────
+# Vercel's Python runtime imports this file from /var/task with /var/task on
+# sys.path, so `from logic.classifier import ...` would look for
+# /var/task/logic/ and fail (it lives at /var/task/api/logic/).
+# Inserting this file's directory makes every sibling-style import
+# (logic/, schemas/, lib/, jobs, config) resolve without rewriting all of them
+# to use an `api.` prefix.
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+# ─────────────────────────────────────────────────────────────────────────────
+
 import asyncio
 import json
 import logging


### PR DESCRIPTION
## Summary

Production was 500-ing on every \`/api/v1/*\` call. Vercel runtime log:

\`\`\`
File \"/var/task/api/index.py\", line 17, in <module>
    from logic.classifier import IntentClassifier, SmartClassifier
ModuleNotFoundError: No module named 'logic'
\`\`\`

## Root cause

Vercel's Python runtime imports the entrypoint with **\`/var/task\`** on \`sys.path\`,
not \`/var/task/api/\`. So \`from logic.classifier import ...\` resolves to
\`/var/task/logic/\` (doesn't exist) and crashes the module import — which is why
even trivial handlers like \`/api/v1/byok-status\` returned 500: the whole module
never finished importing.

Locally \`python api/index.py\` happens to put \`api/\` on sys.path, so the same
imports work. That's why this didn't catch before deploy.

## Fix

Insert \`api/index.py\`'s own directory into sys.path **at the top of the file**,
before any sibling import is attempted:

\`\`\`python
import sys
from pathlib import Path
sys.path.insert(0, str(Path(__file__).resolve().parent))
\`\`\`

Considered the alternative — rewriting every import across \`api/{logic,schemas,
lib}/**.py\` plus \`api/{jobs,config}.py\` with an \`api.\` prefix — but that's 40+
touch points for the same effect, and api/index.py is the single Vercel
entrypoint so a one-line shim is the right scope.

## Test plan

After merge:
- [ ] \`curl https://mindbusiness.vercel.app/api/v1/byok-status\` → \`{\"has_server_key\": false}\`
- [ ] \`curl -X POST .../api/v1/jobs/report ...\` → 202 + \`{job_id}\`
- [ ] Vercel logs show no more \`ModuleNotFoundError\`
- [ ] Browser: input → ⮕ → smart-classify succeeds, /map loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)