### PR TITLE
feat: 최근 아이디어 리스트 + 홈/캔버스 UI 다듬기 + 로컬 dev proxy

### DIFF
--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -60,7 +60,11 @@ function getParentSiblingLabels(
 
 export default function MapPageContent() {
     const searchParams = useSearchParams()
-    const topic = searchParams.get('topic') || ''
+    const idFromUrl = searchParams.get('id') || ''
+    // Legacy URL fallback — pre-id maps used `?topic=`. We accept it on
+    // first hit, migrate the cache key to the new id, and stop using the
+    // topic for persistence.
+    const legacyTopic = searchParams.get('topic') || ''
     const framework = searchParams.get('framework') || 'BMC'
     const intent = searchParams.get('intent') || 'creation'
     // free=1 → "자유롭게 시작하기" path: skip skeleton, mount root only.
@@ -75,8 +79,11 @@ export default function MapPageContent() {
         contextPath,
         expandingNodeId,
         isLoading,
+        topic: storeTopic,
         setRootNode,
         setTopic,
+        setMindmapId,
+        setFrameworkId,
         navigateTo,
         setExpanding,
         setLoading,
@@ -85,28 +92,43 @@ export default function MapPageContent() {
 
     const [reportOpen, setReportOpen] = useState(false)
 
-    // Bind topic to store so mutations persist to tree-cache automatically.
+    // Bind id to store so mutations persist to tree-cache under it. If the
+    // URL only carries a legacy ?topic= we mint a fresh id; the cache
+    // migration happens inside the loadTree call below (legacyTopic
+    // fallback recovers the old entry, then setRootNode persists it under
+    // the new id).
+    const effectiveId = idFromUrl || (legacyTopic ? `legacy-${legacyTopic.slice(0, 8)}` : '')
     useEffect(() => {
-        setTopic(topic || null)
-    }, [topic, setTopic])
+        if (effectiveId) setMindmapId(effectiveId)
+        if (legacyTopic && !storeTopic) setTopic(legacyTopic)
+        // Mirror the framework into the store so persistTree() knows which
+        // framework this map uses — the recent-maps list reads it from
+        // there to rebuild ?framework= when the user re-opens.
+        if (framework) setFrameworkId(framework)
+    }, [effectiveId, legacyTopic, storeTopic, framework, setMindmapId, setTopic, setFrameworkId])
 
     // Initial Load: L1 노드 표시 (Backend에서 받은 l1_labels 우선 사용)
     useEffect(() => {
-        if (!topic || !framework) return
+        if (!effectiveId || !framework) return
         if (rootNode) return  // 이미 로드됨
+
+        // The label we'll seed the root with when no cache hit recovers a
+        // real one. Prefer the live store value (set by the home page
+        // before navigating here), then the legacy ?topic=, then fallbacks.
+        const seedTopic = storeTopic || legacyTopic || ""
 
         // 1) "자유롭게 시작하기" path — single root node, no L1 children.
         //    Label is editable inline so the user can rename right away.
         //    On refresh / new-tab the in-memory store is empty, so try
         //    tree-cache first to recover any edits the user already made.
         if (isFreeStart) {
-            const cached = topic ? loadTree(topic) : null
+            const cached = loadTree(idFromUrl, legacyTopic || undefined)
             if (cached) {
                 setRootNode(cached)
             } else {
                 setRootNode({
                     id: 'root',
-                    label: topic,
+                    label: seedTopic || '새 아이디어',
                     type: 'root',
                     description: '자유 마인드맵',
                     children: [],
@@ -121,20 +143,30 @@ export default function MapPageContent() {
         //    that case. If we got here, the in-memory store is empty (user
         //    refreshed or opened the URL in a new tab), so try tree-cache;
         //    fall back to a blank root rather than rendering null forever
-        //    when the cache also lost the topic.
+        //    when the cache also lost the entry.
         if (isLoaded) {
-            const cached = topic ? loadTree(topic) : null
+            const cached = loadTree(idFromUrl, legacyTopic || undefined)
             if (cached) {
                 setRootNode(cached)
             } else {
                 setRootNode({
                     id: 'root',
-                    label: topic || '불러온 마인드맵',
+                    label: seedTopic || '불러온 마인드맵',
                     type: 'root',
                     description: '복원할 데이터를 찾지 못했어요. 다시 불러와 주세요.',
                     children: [],
                 })
             }
+            setLoading(false)
+            return
+        }
+
+        // 3) Normal smart-classify path — try the cache first (covers
+        //    refresh after user has been editing) before consuming the
+        //    one-shot l1_labels from localStorage.
+        const cached = loadTree(idFromUrl, legacyTopic || undefined)
+        if (cached) {
+            setRootNode(cached)
             setLoading(false)
             return
         }
@@ -149,7 +181,7 @@ export default function MapPageContent() {
                 // Backend에서 받은 Intent별 맞춤형 L1으로 Skeleton 생성
                 const rootNode: MindmapNode = {
                     id: 'root',
-                    label: topic,
+                    label: seedTopic,
                     type: 'root',
                     description: `${framework} Framework (${intent})`,
                     children: l1Labels.map((item, index) => ({
@@ -168,17 +200,29 @@ export default function MapPageContent() {
             } catch (e) {
                 console.error('Failed to parse l1_labels:', e)
                 // Fallback: Frontend 템플릿 사용
-                const skeleton = createSkeletonTree(topic, framework, 'Korean', intent)
+                const skeleton = createSkeletonTree(seedTopic, framework, 'Korean', intent)
                 setRootNode(skeleton)
             }
         } else {
             // Fallback: Frontend 템플릿 사용 (직접 URL 접근 등)
-            const skeleton = createSkeletonTree(topic, framework, 'Korean', intent)
+            const skeleton = createSkeletonTree(seedTopic, framework, 'Korean', intent)
             setRootNode(skeleton)
         }
 
         setLoading(false)
-    }, [topic, framework, intent, rootNode, setRootNode, setLoading, isFreeStart, isLoaded])
+    }, [
+        effectiveId,
+        idFromUrl,
+        legacyTopic,
+        storeTopic,
+        framework,
+        intent,
+        rootNode,
+        setRootNode,
+        setLoading,
+        isFreeStart,
+        isLoaded,
+    ])
 
     // Handle node expansion (supports add mode)
     const handleExpand = useCallback(async (node: MindmapNode) => {
@@ -230,13 +274,17 @@ export default function MapPageContent() {
             ]
             storeExpandNode(node.id, newChildren)
 
-            // Save tree to cache
-            const updatedRoot = useMindmapStore.getState().rootNode
-            if (updatedRoot) {
-                saveTree(topic, updatedRoot)
+            // Save tree to cache (store mutations also persist on their
+            // own; this is just defense-in-depth for the expand flow).
+            const state = useMindmapStore.getState()
+            if (state.rootNode && state.mindmapId) {
+                saveTree(state.mindmapId, state.rootNode, {
+                    frameworkId: state.frameworkId ?? undefined,
+                    topic: state.topic ?? undefined,
+                })
             }
 
-            toast.success('노드 확장 완료!', {
+            toast.success('아이디어 확장 완료!', {
                 description: `${response.children.length}개 하위 항목 추가됨`
             })
         } catch (error) {
@@ -245,7 +293,7 @@ export default function MapPageContent() {
             })
             setExpanding(null)
         }
-    }, [rootNode, contextPath, framework, setExpanding, storeExpandNode, topic])
+    }, [rootNode, contextPath, framework, setExpanding, storeExpandNode])
 
 
 
@@ -270,12 +318,13 @@ export default function MapPageContent() {
                 />
             </div>
 
-            {/* Report Panel */}
+            {/* Report Panel — title comes from the live root label so an
+                edit on the root propagates into the report immediately. */}
             <ReportPanel
                 open={reportOpen}
                 onOpenChange={setReportOpen}
                 rootNode={rootNode}
-                topic={topic}
+                topic={rootNode.label || storeTopic || legacyTopic}
                 frameworkId={framework}
             />
         </main>

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -125,7 +125,7 @@ export default function MapPageContent() {
         //    On refresh / new-tab the in-memory store is empty, so try
         //    tree-cache first to recover any edits the user already made.
         if (isFreeStart) {
-            const cached = loadTree(idFromUrl, legacyTopic || undefined)
+            const cached = loadTree(effectiveId, legacyTopic || undefined)
             if (cached) {
                 setRootNode(cached)
             } else {
@@ -148,7 +148,7 @@ export default function MapPageContent() {
         //    fall back to a blank root rather than rendering null forever
         //    when the cache also lost the entry.
         if (isLoaded) {
-            const cached = loadTree(idFromUrl, legacyTopic || undefined)
+            const cached = loadTree(effectiveId, legacyTopic || undefined)
             if (cached) {
                 setRootNode(cached)
             } else {
@@ -166,8 +166,10 @@ export default function MapPageContent() {
 
         // 3) Normal smart-classify path — try the cache first (covers
         //    refresh after user has been editing) before consuming the
-        //    one-shot l1_labels from localStorage.
-        const cached = loadTree(idFromUrl, legacyTopic || undefined)
+        //    one-shot l1_labels from localStorage. Loading via
+        //    effectiveId (not idFromUrl) ensures legacy URL refreshes
+        //    keep finding their migrated entry instead of the stale slug.
+        const cached = loadTree(effectiveId, legacyTopic || undefined)
         if (cached) {
             setRootNode(cached)
             setLoading(false)

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -6,7 +6,7 @@ import { MindmapCanvas } from "@/components/mindmap/mindmap-canvas"
 import { ReportPanel } from "@/components/mindmap/report-panel"
 import { useMindmapStore } from "@/stores/mindmap-store"
 import { expandNode } from "@/lib/api"
-import { loadTree, saveTree } from "@/lib/tree-cache"
+import { loadTree, saveTree, legacyIdFromTopic } from "@/lib/tree-cache"
 import { createSkeletonTree } from "@/lib/framework-templates"
 import { MindmapNode, ExpandRequest } from "@/types/mindmap"
 import { toast } from "sonner"
@@ -97,7 +97,10 @@ export default function MapPageContent() {
     // migration happens inside the loadTree call below (legacyTopic
     // fallback recovers the old entry, then setRootNode persists it under
     // the new id).
-    const effectiveId = idFromUrl || (legacyTopic ? `legacy-${legacyTopic.slice(0, 8)}` : '')
+    // For legacy `?topic=` URLs, derive a stable hash-based id so two
+    // topics that share a prefix (e.g. "AI 자동화 생산성" / "AI 자동화 비즈니스")
+    // don't collide in tree-cache.
+    const effectiveId = idFromUrl || (legacyTopic ? legacyIdFromTopic(legacyTopic) : '')
     useEffect(() => {
         if (effectiveId) setMindmapId(effectiveId)
         if (legacyTopic && !storeTopic) setTopic(legacyTopic)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,19 +5,27 @@ import { useRouter } from "next/navigation"
 import { motion, AnimatePresence } from "framer-motion"
 import { smartClassify } from "@/lib/api"
 import { LOADING_QUOTES, LoadingQuote } from "@/lib/framework-templates"
+import { generateMindmapId } from "@/lib/tree-cache"
 import { toast } from "sonner"
-import { HeroInput, LoadingScreen, IntentMode } from "@/components/landing"
+import { HeroInput, LoadingScreen, IntentMode, RecentMapsList } from "@/components/landing"
 import { SaveLoadButtons } from "@/components/mindmap/save-load-buttons"
 import { DottedGlowBackground } from "@/components/ui/dotted-glow-background"
 import { ConversationMessage, SmartClassifyResponse, isAPIError } from "@/types/mindmap"
 import { isAnyKeyAvailable, openApiKeySettings } from "@/lib/api-key-store"
+import { useMindmapStore } from "@/stores/mindmap-store"
 import { HugeiconsIcon } from '@hugeicons/react'
-import { ArrowRight02Icon } from '@hugeicons/core-free-icons'
+import { ArrowRight02Icon, SparklesIcon } from '@hugeicons/core-free-icons'
+import { Button } from '@/components/ui/button'
 
 type Step = "input" | "loading" | "question" | "generating"
 
 export default function HomePage() {
     const router = useRouter()
+    // Pre-seed the mindmap store before navigating so the /map page picks
+    // up the topic + id without needing them in the URL (URL stays short
+    // with just ?id=).
+    const setStoreMindmapId = useMindmapStore((s) => s.setMindmapId)
+    const setStoreTopic = useMindmapStore((s) => s.setTopic)
     const [step, setStep] = useState<Step>("input")
     const [topic, setTopic] = useState("")
     const [intentMode, setIntentMode] = useState<IntentMode>('creation')
@@ -111,7 +119,10 @@ export default function HomePage() {
                 pendingNavTimer.current = setTimeout(() => {
                     pendingNavTimer.current = null
                     const framework = result.selected_framework_id || "LEAN"
-                    router.push(`/map?topic=${encodeURIComponent(finalSummary)}&framework=${framework}&intent=${intentMode}`)
+                    const id = generateMindmapId()
+                    setStoreMindmapId(id)
+                    setStoreTopic(finalSummary)
+                    router.push(`/map?id=${id}&framework=${framework}&intent=${intentMode}`)
                 }, 1500)
             }
             else {
@@ -124,7 +135,10 @@ export default function HomePage() {
                     localStorage.setItem('mindmap_l1_labels', JSON.stringify(result.l1_labels))
                 }
 
-                router.push(`/map?topic=${encodeURIComponent(finalSummary)}&framework=${framework}&intent=${intentMode}`)
+                const id = generateMindmapId()
+                setStoreMindmapId(id)
+                setStoreTopic(finalSummary)
+                router.push(`/map?id=${id}&framework=${framework}&intent=${intentMode}`)
             }
         } catch (error: unknown) {
             // API 에러 응답인지 확인 (api.ts에서 throw된 객체)
@@ -165,7 +179,7 @@ export default function HomePage() {
     }
 
     return (
-        <main className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-slate-50 font-sans text-slate-900 selection:bg-indigo-100 selection:text-indigo-900">
+        <main className="relative flex min-h-screen w-full items-center justify-center overflow-x-hidden bg-slate-50 font-sans text-slate-900 selection:bg-indigo-100 selection:text-indigo-900 py-12">
             {/* Background Pattern */}
             <DottedGlowBackground
                 className="pointer-events-none z-0"
@@ -197,22 +211,29 @@ export default function HomePage() {
                                 apiKeyError={apiKeyError}
                                 onApiKeyErrorClear={() => setApiKeyError("")}
                             />
-                            {/* Secondary actions: 자유 시작 + 불러오기 */}
-                            <div className="mt-6 flex items-center gap-4 text-sm text-slate-400">
-                                <button
+                            {/* Secondary actions: 자유 시작 + 불러오기 — outline 버튼 통일,
+                                자유 시작은 indigo accent로 시선 유도 (메인 input의 focus 색과 호응) */}
+                            <div className="mt-6 flex items-center gap-2">
+                                <Button
                                     type="button"
-                                    onClick={() =>
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => {
+                                        const id = generateMindmapId()
+                                        setStoreMindmapId(id)
+                                        setStoreTopic("새 아이디어")
                                         router.push(
-                                            `/map?topic=${encodeURIComponent("새 아이디어")}&framework=LOGIC&intent=creation&free=1`,
+                                            `/map?id=${id}&framework=LOGIC&intent=creation&free=1`,
                                         )
-                                    }
-                                    className="hover:text-slate-700 transition-colors underline-offset-4 hover:underline"
+                                    }}
+                                    className="flex items-center gap-1.5 border-indigo-200 text-indigo-600 bg-white/60 hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-700"
                                 >
-                                    또는 자유롭게 시작하기 →
-                                </button>
-                                <span className="text-slate-200">·</span>
+                                    <HugeiconsIcon icon={SparklesIcon} size={16} />
+                                    <span className="text-sm font-medium">자유롭게 시작</span>
+                                </Button>
                                 <SaveLoadButtons showSave={false} />
                             </div>
+                            <RecentMapsList />
                         </motion.div>
                     )}
 

--- a/components/landing/hero-input.tsx
+++ b/components/landing/hero-input.tsx
@@ -25,7 +25,7 @@ const INTENT_OPTIONS: IntentOption[] = [
         question: (
             <>
                 어떤 <strong className="font-semibold text-slate-800">아이디어</strong>를<br />
-                <strong className="font-semibold text-slate-800">구체적 계획</strong>으로 만들고 싶으세요?
+                <strong className="font-semibold text-slate-800">구체적인 계획</strong>으로 만들까요?
             </>
         )
     },
@@ -35,7 +35,9 @@ const INTENT_OPTIONS: IntentOption[] = [
         icon: AiSearch02Icon,
         question: (
             <>
-                지금 겪고 계신 어떤 <strong className="font-semibold text-slate-800">문제의<br />원인</strong>을 찾고 싶으세요?
+                지금 겪고 있는<br />
+                어떤 <strong className="font-semibold text-slate-800">문제</strong>를{" "}
+                <strong className="font-semibold text-slate-800">해결</strong>할까요?
             </>
         )
     },
@@ -45,7 +47,8 @@ const INTENT_OPTIONS: IntentOption[] = [
         icon: JusticeScale01Icon,
         question: (
             <>
-                어떤 선택지들 중에서<br /><strong className="font-semibold text-slate-800">최선의 결정</strong>을 내리고 싶으세요?
+                어떤 <strong className="font-semibold text-slate-800">선택지들</strong>과<br />
+                <strong className="font-semibold text-slate-800">고민</strong>을 하고 있나요?
             </>
         )
     },
@@ -55,7 +58,8 @@ const INTENT_OPTIONS: IntentOption[] = [
         icon: Flag01Icon,
         question: (
             <>
-                앞으로의 어떤 <strong className="font-semibold text-slate-800">목표</strong>를 세우거나<br /><strong className="font-semibold text-slate-800">회고</strong>하고 싶으세요?
+                어떤 <strong className="font-semibold text-slate-800">목표</strong>를 세우거나<br />
+                <strong className="font-semibold text-slate-800">점검</strong>하고 싶으세요?
             </>
         )
     }
@@ -174,10 +178,21 @@ export function HeroInput({ topic, onTopicChange, onSubmit, intentMode, onIntent
                 ease: [0.25, 0.46, 0.45, 0.94],
                 delay: 0.1
             }}
-            className="flex flex-col items-center"
+            className="flex w-full flex-col items-center"
         >
+            {/* Dynamic Title based on Intent */}
+            <motion.h1
+                key={intentMode}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+                className="mb-8 text-center text-2xl font-light tracking-tight text-slate-700 md:text-3xl px-4"
+            >
+                {currentIntent.question}
+            </motion.h1>
+
             {/* Intent Mode Selector */}
-            <div className="mb-8 grid grid-cols-2 md:flex md:flex-wrap md:justify-center gap-2">
+            <div className="mb-4 grid grid-cols-2 md:flex md:flex-wrap md:justify-center gap-2">
                 {INTENT_OPTIONS.map((option) => (
                     <button
                         key={option.id}
@@ -192,17 +207,6 @@ export function HeroInput({ topic, onTopicChange, onSubmit, intentMode, onIntent
                     </button>
                 ))}
             </div>
-
-            {/* Dynamic Title based on Intent */}
-            <motion.h1
-                key={intentMode}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3 }}
-                className="mb-4 text-center text-2xl font-light tracking-tight text-slate-700 md:text-3xl px-4"
-            >
-                {currentIntent.question}
-            </motion.h1>
 
             {/* Textarea Form with Shake Animation */}
             <motion.form

--- a/components/landing/index.ts
+++ b/components/landing/index.ts
@@ -1,3 +1,4 @@
 export { HeroInput, type IntentMode } from './hero-input'
 export { LoadingScreen } from './loading-screen'
 export { FrameworkSelector } from './framework-selector'
+export { RecentMapsList } from './recent-maps-list'

--- a/components/landing/recent-maps-list.tsx
+++ b/components/landing/recent-maps-list.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { AiIdeaIcon, Clock01Icon, Delete02Icon } from "@hugeicons/core-free-icons"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { listRecentMaps, clearTree, type RecentMapEntry } from "@/lib/tree-cache"
+
+const COLLAPSED_LIMIT = 5
+
+/** Best-effort: ask the browser to keep our origin's data through eviction. */
+function requestPersistence() {
+    if (typeof navigator === "undefined") return
+    const storage = navigator.storage
+    if (!storage || typeof storage.persist !== "function") return
+    // Fire-and-forget. Safari ignores this; Chrome/FF may grant it. Either
+    // way, calling is free and we don't surface the result to the user.
+    storage.persist().catch(() => {})
+}
+
+/** "방금 전" / "3시간 전" / "2025-05-01" — short Korean relative-time. */
+function formatRelativeTime(ms: number): string {
+    const diff = Date.now() - ms
+    const min = 60_000
+    const hour = 60 * min
+    const day = 24 * hour
+
+    if (diff < min) return "방금 전"
+    if (diff < hour) return `${Math.floor(diff / min)}분 전`
+    if (diff < day) return `${Math.floor(diff / hour)}시간 전`
+    if (diff < 7 * day) return `${Math.floor(diff / day)}일 전`
+
+    const d = new Date(ms)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+/**
+ * Recent maps list for the home page.
+ *
+ * localStorage entries are scanned on mount; nothing is rendered when the
+ * list is empty so first-time users still see the bare hero input. Click
+ * → re-opens the map at `/map?id=...&framework=...`. Trash icon →
+ * AlertDialog confirm → removes the entry.
+ *
+ * Note: localStorage is best-effort persistence. Safari ITP wipes
+ * script-writable storage after 7 days of no interaction, and any
+ * browser may evict under storage pressure. We try `navigator.storage
+ * .persist()` once on mount but don't promise the user anything beyond
+ * "we'll keep your maps here while we can — download OPML for safekeeping."
+ */
+export function RecentMapsList() {
+    const router = useRouter()
+    const [maps, setMaps] = useState<RecentMapEntry[] | null>(null)
+    const [expanded, setExpanded] = useState(false)
+    const [pendingDelete, setPendingDelete] = useState<RecentMapEntry | null>(null)
+
+    useEffect(() => {
+        // One-shot hydration from localStorage, not a subscription — running
+        // this in render would cause SSR/CSR hydration mismatch (server has
+        // no localStorage, client does). useSyncExternalStore would over-
+        // engineer this for a list that only changes when the user clicks
+        // a delete button on this same component.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setMaps(listRecentMaps())
+        requestPersistence()
+    }, [])
+
+    if (maps === null) return null
+    if (maps.length === 0) return null
+
+    const visible = expanded ? maps : maps.slice(0, COLLAPSED_LIMIT)
+    const hasMore = maps.length > COLLAPSED_LIMIT
+
+    const handleOpen = (m: RecentMapEntry) => {
+        router.push(
+            `/map?id=${m.id}&framework=${encodeURIComponent(m.frameworkId)}`,
+        )
+    }
+
+    const confirmDelete = () => {
+        if (!pendingDelete) return
+        clearTree(pendingDelete.id)
+        setMaps((prev) => prev?.filter((m) => m.id !== pendingDelete.id) ?? null)
+        toast.success("아이디어를 삭제했어요")
+        setPendingDelete(null)
+    }
+
+    return (
+        <div className="mt-10 w-full max-w-lg md:max-w-xl">
+            <h2 className="mb-2 px-1 text-xs font-medium tracking-wide text-slate-400">
+                최근 아이디어
+            </h2>
+
+            <ul>
+                {visible.map((m) => (
+                    <li
+                        key={m.id}
+                        className="group flex items-center gap-2"
+                    >
+                        <button
+                            type="button"
+                            onClick={() => handleOpen(m)}
+                            className="flex-1 min-w-0 truncate py-1.5 text-left text-sm text-slate-700 transition-colors hover:text-indigo-600"
+                        >
+                            <span
+                                className="mr-2 text-base leading-none text-indigo-500"
+                                aria-hidden="true"
+                            >
+                                •
+                            </span>
+                            {m.title}
+                            <span className="ml-2 inline-flex items-center gap-1 text-xs text-slate-400 align-middle">
+                                <HugeiconsIcon icon={Clock01Icon} size={12} />
+                                {formatRelativeTime(m.lastUpdated)}
+                                <span aria-hidden="true" className="mx-0.5">·</span>
+                                <HugeiconsIcon icon={AiIdeaIcon} size={12} />
+                                {m.nodeCount}개 아이디어
+                            </span>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setPendingDelete(m)}
+                            className="shrink-0 rounded p-1 text-slate-300 opacity-0 transition-opacity hover:text-rose-500 group-hover:opacity-100"
+                            aria-label={`${m.title} 삭제`}
+                        >
+                            <HugeiconsIcon icon={Delete02Icon} size={14} />
+                        </button>
+                    </li>
+                ))}
+            </ul>
+
+            {hasMore && (
+                <div className="mt-3 flex justify-center">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setExpanded((v) => !v)}
+                        className="text-xs text-slate-500"
+                    >
+                        {expanded ? "접기" : `${maps.length - COLLAPSED_LIMIT}개 더 보기`}
+                    </Button>
+                </div>
+            )}
+
+            {/* Persistence caveat — keeps the auto-save promise honest.
+                Browsers can evict localStorage (Safari: 7-day ITP, others:
+                storage pressure), so users should know to download OPML
+                if a map matters. */}
+            <p className="mt-3 px-1 text-[11px] leading-relaxed text-slate-400 break-keep">
+                브라우저 데이터가 정리되거나 1주일 이상 접속하지 않으면 사라질 수
+                있으니, 중요한 아이디어는{" "}
+                <strong className="font-medium text-slate-500">다운로드</strong>{" "}
+                버튼으로 백업해 두세요.
+            </p>
+
+            <AlertDialog
+                open={pendingDelete !== null}
+                onOpenChange={(open) => !open && setPendingDelete(null)}
+            >
+                <AlertDialogContent className="bg-white">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle className="text-slate-900">
+                            이 아이디어를 삭제할까요?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription className="text-slate-500 break-keep leading-relaxed">
+                            <strong className="text-slate-700">
+                                &ldquo;{pendingDelete?.title}&rdquo;
+                            </strong>
+                            을(를) 영구적으로 삭제합니다. 다시 복구할 수 없으니,
+                            보관이 필요하면 먼저 다운로드해 주세요.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel className="min-w-[100px]">
+                            취소
+                        </AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={confirmDelete}
+                            className="min-w-[160px] bg-rose-600 hover:bg-rose-700 border-rose-600 hover:border-rose-700 text-white shadow-md"
+                        >
+                            삭제
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    )
+}

--- a/components/mindmap/home-button.tsx
+++ b/components/mindmap/home-button.tsx
@@ -20,9 +20,12 @@ import {
 /**
  * Home / back-to-main button with a confirmation step.
  *
- * The mindmap is auto-persisted to tree-cache on every mutation, so going
- * back doesn't actually lose anything — the dialog copy says so explicitly
- * to keep the user from feeling like they need to "save first".
+ * The mindmap is auto-persisted to tree-cache on every mutation and
+ * surfaces in the home page's "최근 마인드맵" list. The dialog copy
+ * names that list so users know where to find the map again — and warns
+ * that browser data isn't permanent (Safari ITP wipes after 7 days, any
+ * browser may evict under storage pressure), nudging them toward the
+ * download button for anything important.
  */
 export function HomeButton() {
     const router = useRouter()
@@ -40,7 +43,7 @@ export function HomeButton() {
                 }
             >
                 <HugeiconsIcon icon={Home01Icon} size={16} />
-                <span className="text-sm font-medium">메인</span>
+                <span className="text-sm font-medium">메인으로</span>
             </AlertDialogTrigger>
             <AlertDialogContent className="bg-white">
                 <AlertDialogHeader>
@@ -48,14 +51,22 @@ export function HomeButton() {
                         메인으로 돌아갈까요?
                     </AlertDialogTitle>
                     <AlertDialogDescription className="text-slate-500 break-keep leading-relaxed">
-                        지금까지 작성한 마인드맵은 자동으로 저장되어, 같은 주제로 다시 들어오면
-                        이어서 편집할 수 있어요. 다른 곳에서도 보관하려면 우상단 <strong>저장</strong>{" "}
-                        버튼으로 OPML/JSON 파일을 받아두는 걸 권장해요.
+                        지금까지 작성한 아이디어는 <strong>최근 아이디어 리스트</strong>
+                        에서 다시 열 수 있어요.
+                        <br />
+                        브라우저에 저장되는 방식이라 데이터가 정리되거나 1주일 이상
+                        접속하지 않으면 사라질 수 있으니, 중요한 아이디어는{" "}
+                        <strong>다운로드 버튼</strong>으로 백업해 두세요.
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                    <AlertDialogCancel>취소</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => router.push("/")}>
+                    <AlertDialogCancel className="min-w-[100px]">
+                        취소
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={() => router.push("/")}
+                        className="min-w-[160px]"
+                    >
                         메인으로
                     </AlertDialogAction>
                 </AlertDialogFooter>

--- a/components/mindmap/mindmap-canvas.tsx
+++ b/components/mindmap/mindmap-canvas.tsx
@@ -6,6 +6,7 @@ import {
     Node,
     Edge,
     Controls,
+    ControlButton,
     useNodesState,
     useEdgesState,
     MiniMap,
@@ -26,6 +27,18 @@ import { calculateD3Layout } from '@/lib/d3-layout'
 import { useMindmapStore } from '@/stores/mindmap-store'
 import { HomeButton } from '@/components/mindmap/home-button'
 import { SaveLoadButtons } from '@/components/mindmap/save-load-buttons'
+import { Button } from '@/components/ui/button'
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 
 interface MindmapCanvasProps {
     rootNode: MindmapNode
@@ -145,8 +158,12 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
     const targetPos = data.side === 'left' ? Position.Right : Position.Left
     const sourcePos = data.side === 'left' ? Position.Left : Position.Right
 
-    // L1 이상 노드에서 NodeToolbar 표시 (Root 제외)
-    const showToolbar = data.level >= 1
+    // Toolbar visible on every node, including the root. The root is the
+    // user's mindmap title and should be editable; we just hide the delete
+    // action because removing the root makes no sense (and the store's
+    // deleteNode already refuses it).
+    const showToolbar = true
+    const canDelete = !isRoot
 
     // 확장 버튼 표시 조건: level < 4 AND children < max
     const maxChildren = MAX_CHILDREN_PER_LEVEL[data.level] || 5
@@ -207,17 +224,19 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         <HugeiconsIcon icon={PencilEdit01Icon} size={16} />
                     </button>
 
-                    {/* 4. 삭제 */}
-                    <button
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            data.onDelete?.()
-                        }}
-                        className="p-1.5 rounded-md bg-white/90 hover:bg-red-100 text-slate-600 hover:text-red-600 shadow-sm border border-slate-200 transition-colors"
-                        title="삭제"
-                    >
-                        <HugeiconsIcon icon={Delete02Icon} size={16} />
-                    </button>
+                    {/* 4. 삭제 (root는 숨김) */}
+                    {canDelete && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                data.onDelete?.()
+                            }}
+                            className="p-1.5 rounded-md bg-white/90 hover:bg-red-100 text-slate-600 hover:text-red-600 shadow-sm border border-slate-200 transition-colors"
+                            title="삭제"
+                        >
+                            <HugeiconsIcon icon={Delete02Icon} size={16} />
+                        </button>
+                    )}
                 </NodeToolbar>
             )}
             <NodeStatusIndicator
@@ -261,7 +280,7 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                                         el.select()
                                     }
                                 }}
-                                placeholder="노드 이름 입력..."
+                                placeholder="아이디어 입력..."
                                 className="nodrag px-2 py-1 text-base font-semibold bg-white border border-indigo-400 rounded outline-none focus:ring-2 focus:ring-indigo-500 text-slate-800 min-w-[100px]"
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter') {
@@ -293,7 +312,7 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                                     ${style.hasUnderline && style.underlineWeight === 'bold' ? 'border-b-2 border-slate-800' : ''}
                                 `}
                             >
-                                {data.label || '(빈 노드)'}
+                                {data.label || '(빈 아이디어)'}
                             </span>
                         )}
                     </div>
@@ -527,6 +546,14 @@ function MindmapCanvasInner({
         onNodeSelect?.(mindmapNode)
     }, [onNodeSelect, expanding])
 
+    // 더블 클릭 / 더블 탭 → 인라인 편집 모드. React Flow가 mouse + touch
+    // double-tap 둘 다 onNodeDoubleClick으로 발화시키므로 모바일도 자동 커버됨.
+    const handleNodeDoubleClick = useCallback((event: React.MouseEvent, node: Node) => {
+        if (expanding) return
+        const mindmapNode = node.data.node as MindmapNode
+        setEditingNodeId(mindmapNode.id)
+    }, [expanding, setEditingNodeId])
+
     return (
         <div className="relative w-full h-full min-h-screen bg-slate-50">
             {/* Aceternity Dotted Glow Background */}
@@ -548,6 +575,7 @@ function MindmapCanvasInner({
                     onNodesChange={onNodesChange}
                     onEdgesChange={onEdgesChange}
                     onNodeClick={handleNodeClick}
+                    onNodeDoubleClick={handleNodeDoubleClick}
                     nodeTypes={nodeTypes}
                     nodesDraggable={!expanding}
                     fitViewOptions={{ padding: 0.3 }}
@@ -556,49 +584,96 @@ function MindmapCanvasInner({
                     maxZoom={2}
                     proOptions={{ hideAttribution: true }}
                 >
-                    {/* 좌상단: 메인 + 재정렬 (탐색·뷰 컨트롤) */}
+                    {/* 좌상단: 메인 버튼만 */}
                     <Panel position="top-left" className="m-4">
-                        <div className="flex gap-2">
-                            <HomeButton />
-                            <button
-                                onClick={() => {
-                                    hasFittedView.current = false
-                                    setNodes(layoutedNodes)
-                                    setEdges(layoutedEdges)
-                                    if (fitViewTimerRef.current) clearTimeout(fitViewTimerRef.current)
-                                    fitViewTimerRef.current = setTimeout(() => {
-                                        fitView({ padding: 0.3, duration: 500 })
-                                        hasFittedView.current = true
-                                        fitViewTimerRef.current = null
-                                    }, 100)
-                                }}
-                                className="flex items-center gap-2 px-3 py-2 bg-white hover:bg-slate-100 text-slate-700 rounded-lg shadow-md border border-slate-200 transition-colors"
-                                title="노드 재정렬"
-                            >
-                                <HugeiconsIcon icon={RefreshIcon} size={16} />
-                                <span className="text-sm font-medium">재정렬</span>
-                            </button>
-                        </div>
+                        <HomeButton />
                     </Panel>
 
-                    {/* 우상단: 저장/불러오기 + 기획서 (저장·산출물) */}
+                    {/* 우상단: 저장/불러오기 + 기획서 (저장·산출물).
+                        모든 버튼이 shadcn Button size="sm" (h-8) 로 통일되어
+                        높이가 정렬됩니다. 기획서만 indigo accent로 primary
+                        action임을 표시. */}
                     <Panel position="top-right" className="m-4">
                         <div className="flex gap-2">
                             <SaveLoadButtons />
                             {onReportOpen && (
-                                <button
-                                    onClick={onReportOpen}
-                                    className="flex items-center gap-2 px-3 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg shadow-md transition-colors"
-                                    title="AI 기획서 생성"
-                                >
-                                    <HugeiconsIcon icon={NoteIcon} size={16} />
-                                    <span className="text-sm font-medium">기획서</span>
-                                </button>
+                                <AlertDialog>
+                                    <AlertDialogTrigger
+                                        render={
+                                            <Button
+                                                size="sm"
+                                                title="AI 기획서 작성"
+                                                // shadcn Button base는 transparent border + bg-clip-padding
+                                                // 이라 부모 배경이 비쳐 흰 외곽선처럼 보임 → border 색을
+                                                // background와 동일하게 맞춰서 제거.
+                                                className="flex items-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 border-indigo-600 hover:border-indigo-700 text-white shadow-md"
+                                            />
+                                        }
+                                    >
+                                        <HugeiconsIcon icon={NoteIcon} size={16} />
+                                        <span className="text-sm font-medium">기획서 작성</span>
+                                    </AlertDialogTrigger>
+                                    <AlertDialogContent className="bg-white">
+                                        <AlertDialogHeader>
+                                            <AlertDialogTitle className="text-slate-900">
+                                                기획서 작성을 시작할까요?
+                                            </AlertDialogTitle>
+                                            <AlertDialogDescription className="text-slate-500 break-keep leading-relaxed">
+                                                지금 아이디어를 바탕으로 기획서를 작성합니다.
+                                                <br />
+                                                대략 1-2분 정도 소요되며, 작성 중에도 아이디어를 편집할 수 있어요.
+                                            </AlertDialogDescription>
+                                        </AlertDialogHeader>
+                                        <AlertDialogFooter>
+                                            <AlertDialogCancel className="min-w-[100px]">
+                                                취소
+                                            </AlertDialogCancel>
+                                            <AlertDialogAction
+                                                onClick={onReportOpen}
+                                                className="min-w-[160px] bg-indigo-600 hover:bg-indigo-700 border-indigo-600 hover:border-indigo-700 text-white shadow-md"
+                                            >
+                                                작성하기
+                                            </AlertDialogAction>
+                                        </AlertDialogFooter>
+                                    </AlertDialogContent>
+                                </AlertDialog>
                             )}
                         </div>
                     </Panel>
 
-                    <Controls className="!bg-white !shadow-lg !rounded-lg !border-slate-200" />
+                    {/* Built-in zoom in / zoom out / fit-view + our own "재정렬"
+                        button as a ControlButton so it lives alongside the rest of
+                        the view controls. The interactivity-lock (자물쇠) button is
+                        hidden via showInteractive={false} — streaming-time drag is
+                        already auto-disabled in code, so a manual toggle is noise
+                        for end users. */}
+                    <Controls
+                        showInteractive={false}
+                        className="!bg-white !shadow-lg !rounded-lg !border-slate-200"
+                    >
+                        <ControlButton
+                            onClick={() => {
+                                hasFittedView.current = false
+                                setNodes(layoutedNodes)
+                                setEdges(layoutedEdges)
+                                if (fitViewTimerRef.current) clearTimeout(fitViewTimerRef.current)
+                                fitViewTimerRef.current = setTimeout(() => {
+                                    fitView({ padding: 0.3, duration: 500 })
+                                    hasFittedView.current = true
+                                    fitViewTimerRef.current = null
+                                }, 100)
+                            }}
+                            title="아이디어 재정렬"
+                            aria-label="아이디어 재정렬"
+                            // React Flow's default ".react-flow__controls-button svg
+                            // { fill: currentColor }" inflates HugeiconsIcon's
+                            // stroke-only paths into solid blobs. Override to keep
+                            // the icon as a line drawing.
+                            className="[&_svg]:!fill-none [&_svg]:!stroke-current"
+                        >
+                            <HugeiconsIcon icon={RefreshIcon} size={14} />
+                        </ControlButton>
+                    </Controls>
                     <MiniMap
                         nodeColor={(node) => {
                             const nodeData = node.data as CustomNodeData
@@ -613,7 +688,7 @@ function MindmapCanvasInner({
                         <Panel position="bottom-center" className="bg-indigo-600 text-white px-4 py-2 rounded-lg shadow-lg">
                             <div className="flex items-center gap-2">
                                 <HugeiconsIcon icon={Loading03Icon} size={16} className="animate-spin" />
-                                <span className="text-sm font-medium">노드 확장 중...</span>
+                                <span className="text-sm font-medium">아이디어 확장 중...</span>
                             </div>
                         </Panel>
                     )}

--- a/components/mindmap/save-load-buttons.tsx
+++ b/components/mindmap/save-load-buttons.tsx
@@ -4,31 +4,21 @@ import { useRef } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
-import {
-    Download04Icon,
-    Upload04Icon,
-    ArrowDown01Icon,
-} from "@hugeicons/core-free-icons"
+import { Download04Icon, Upload04Icon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { useMindmapStore } from "@/stores/mindmap-store"
+import { generateMindmapId } from "@/lib/tree-cache"
 import {
     downloadAsFile,
     parseByFilename,
     safeFilename,
-    treeToJSON,
     treeToOPML,
 } from "@/lib/mindmap-format"
 import type { MindmapNode } from "@/types/mindmap"
 
 interface SaveLoadButtonsProps {
-    /** Hides the Save dropdown when there's nothing to save (e.g., on the home page). */
+    /** Hides the Save button when there's nothing to save (e.g., on the home page). */
     showSave?: boolean
     /** Override the post-load destination. Default: navigate to /map with the loaded topic+framework. */
     onLoadOverride?: (parsed: {
@@ -41,8 +31,10 @@ interface SaveLoadButtonsProps {
 /**
  * Save / Load buttons for the mindmap tree.
  *
- * Save → dropdown with OPML / JSON.
- * Load → file picker (auto-detects OPML vs JSON by extension).
+ * Save → downloads an OPML file (lossless via `_`-prefix user attributes;
+ *        also opens cleanly in third-party mindmap apps).
+ * Load → file picker; auto-detects by extension and still accepts legacy
+ *        JSON exports for backward-compat.
  *
  * When loading from the home page, navigates the user to /map. When
  * loading from inside /map (or via `onLoadOverride`) it just swaps the
@@ -61,8 +53,10 @@ export function SaveLoadButtons({
     const topic = useMindmapStore((s) => s.topic)
     const setRootNode = useMindmapStore((s) => s.setRootNode)
     const setTopic = useMindmapStore((s) => s.setTopic)
+    const setMindmapId = useMindmapStore((s) => s.setMindmapId)
+    const setFrameworkId = useMindmapStore((s) => s.setFrameworkId)
 
-    const handleSave = (format: "json" | "opml") => {
+    const handleSave = () => {
         if (!rootNode) {
             toast.error("저장할 마인드맵이 없습니다.")
             return
@@ -75,13 +69,13 @@ export function SaveLoadButtons({
                 : "LOGIC"
         const labelForFile = topic || rootNode.label || "mindmap"
 
-        const content =
-            format === "json"
-                ? treeToJSON(labelForFile, frameworkId, rootNode)
-                : treeToOPML(labelForFile, frameworkId, rootNode)
-        const mime = format === "json" ? "application/json" : "text/xml"
-        downloadAsFile(safeFilename(labelForFile, format), content, mime)
-        toast.success(`${format.toUpperCase()} 파일로 저장했어요`)
+        // OPML round-trips every MindmapNode field via `_`-prefix user
+        // attributes, so a single format covers both interop with other
+        // mindmap apps and re-import into this one — no need to make the
+        // user pick.
+        const content = treeToOPML(labelForFile, frameworkId, rootNode)
+        downloadAsFile(safeFilename(labelForFile, "opml"), content, "text/xml")
+        toast.success("마인드맵을 저장했어요")
     }
 
     const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,11 +92,20 @@ export function SaveLoadButtons({
                 toast.success("마인드맵을 불러왔어요")
                 return
             }
-            // Default: load into store + navigate to /map.
+            // Default: assign a fresh id, seed store, navigate to /map?id=.
+            // setRootNode triggers persistTree() which writes the imported
+            // tree to localStorage under the new id, so a refresh on the
+            // /map page will recover it from cache. Order matters: set the
+            // framework + topic first so the persistTree() inside
+            // setRootNode picks them up and the recent-maps list renders
+            // the correct framework badge / re-open URL.
+            const newId = generateMindmapId()
+            setMindmapId(newId)
+            setFrameworkId(parsed.framework_id)
             setTopic(parsed.topic)
             setRootNode(parsed.root)
             router.push(
-                `/map?topic=${encodeURIComponent(parsed.topic)}&framework=${encodeURIComponent(
+                `/map?id=${newId}&framework=${encodeURIComponent(
                     parsed.framework_id,
                 )}&loaded=1`,
             )
@@ -117,31 +120,15 @@ export function SaveLoadButtons({
     return (
         <div className="flex items-center gap-2">
             {showSave && (
-                <DropdownMenu>
-                    <DropdownMenuTrigger
-                        render={
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="flex items-center gap-1.5"
-                            />
-                        }
-                    >
-                        <HugeiconsIcon icon={Download04Icon} size={16} />
-                        <span className="text-sm font-medium">저장</span>
-                        <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="min-w-[180px]">
-                        <DropdownMenuItem onClick={() => handleSave("opml")}>
-                            <span className="font-mono text-xs text-slate-400">.opml</span>
-                            <span className="ml-2 text-sm">다른 도구로 가져가기</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleSave("json")}>
-                            <span className="font-mono text-xs text-slate-400">.json</span>
-                            <span className="ml-2 text-sm">백업 / 복원용</span>
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSave}
+                    className="flex items-center gap-1.5"
+                >
+                    <HugeiconsIcon icon={Download04Icon} size={16} />
+                    <span className="text-sm font-medium">다운로드</span>
+                </Button>
             )}
 
             <Button

--- a/components/settings/api-key-dialog.tsx
+++ b/components/settings/api-key-dialog.tsx
@@ -113,10 +113,10 @@ export function ApiKeyDialog({ forceOpen, onOpenChange }: ApiKeyDialogProps) {
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
             {/* Trigger: fixed bottom-right icon */}
-            <div className="fixed bottom-4 right-4 z-50 flex items-end gap-2">
+            <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2">
                 {/* Arrow label — only when key is missing */}
                 {needsKey && (
-                    <div className="mb-1 flex items-center gap-1.5 animate-fade-slide">
+                    <div className="flex items-center gap-1.5 animate-fade-slide">
                         <span className="text-xs text-amber-500/80 font-medium whitespace-nowrap">
                             API Key 설정
                         </span>

--- a/lib/mindmap-format.ts
+++ b/lib/mindmap-format.ts
@@ -54,7 +54,7 @@ export function jsonToTree(content: string): ParsedMindmap {
         throw new Error(`지원하지 않는 파일 버전: ${env.version}`)
     }
     if (!env.root || !env.root.id || env.root.label === undefined) {
-        throw new Error("root 노드 정보가 없습니다.")
+        throw new Error("최상위 아이디어 정보가 없습니다.")
     }
     return {
         topic: env.topic ?? "불러온 마인드맵",
@@ -95,11 +95,14 @@ export function treeToOPML(topic: string, frameworkId: string, root: MindmapNode
 
     // The framework_id rides on the root outline as a user attribute so
     // the OPML head stays spec-compliant (head only takes standard fields).
+    // _export_version is the migration anchor for future schema changes —
+    // opmlToTree() can branch on it the way the JSON envelope used to.
     const rootAttrs: string[] = [
         `text="${xmlEscape(root.label || topic)}"`,
         `_id="${xmlEscape(root.id)}"`,
         `_framework_id="${xmlEscape(frameworkId)}"`,
         `_topic="${xmlEscape(topic)}"`,
+        `_export_version="1"`,
     ]
     if (root.type) rootAttrs.push(`_type="${xmlEscape(root.type)}"`)
     if (root.description) rootAttrs.push(`_description="${xmlEscape(root.description)}"`)

--- a/lib/tree-cache.ts
+++ b/lib/tree-cache.ts
@@ -1,8 +1,16 @@
 /**
  * Tree Cache for MindBusiness
- * 
- * Stores the entire mindmap tree in localStorage for persistence across page refreshes.
- * Unlike API cache, this preserves the exact tree state including all expansions.
+ *
+ * Stores the entire mindmap tree in localStorage for persistence across page
+ * refreshes. The cache is keyed by a short random `mindmapId` (12 hex chars
+ * derived from `crypto.randomUUID()`); using a stable random key avoids URL
+ * encoding pain and length blow-up when the topic is long Korean text, and
+ * lets the same topic open multiple independent maps.
+ *
+ * Backward compat: maps created before id-keyed caching used a slug derived
+ * from the topic (`hashTopic`). loadTree() consults the legacy key as a
+ * fallback when the id-keyed entry is missing, so existing in-progress
+ * sessions don't disappear after this rollout.
  */
 
 import { MindmapNode } from '@/types/mindmap'
@@ -13,27 +21,83 @@ interface TreeCacheEntry {
     rootNode: MindmapNode
     createdAt: number
     lastUpdated: number
+    /**
+     * Framework key (BMC, LEAN, LOGIC, …). Required to round-trip the map
+     * via `?framework=` when a user re-opens it from the home page list —
+     * without it we'd have to fall back to LOGIC and lose the originally
+     * chosen framework. Optional for entries written before this field
+     * existed.
+     */
+    frameworkId?: string
+    /**
+     * Display title at write time. We re-derive from `rootNode.label` on
+     * read, but cache it here too so listRecentMaps() can render without
+     * deserializing the whole tree.
+     */
+    topic?: string
 }
 
-/**
- * Generate a simple hash for the topic
- */
-function hashTopic(topic: string): string {
+/** Lightweight summary shown in the recent-maps UI on the home page. */
+export interface RecentMapEntry {
+    id: string
+    title: string
+    /** ms epoch — lastUpdated wins over createdAt for sort. */
+    lastUpdated: number
+    nodeCount: number
+    frameworkId: string
+}
+
+/** Generate a 12-char hex id for a new mindmap. */
+export function generateMindmapId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+    }
+    // Pre-randomUUID browser fallback (extremely rare in 2026, kept for safety).
+    return Math.random().toString(16).slice(2, 14).padEnd(12, '0')
+}
+
+/** Legacy slug — only used for back-compat lookups, never for new writes. */
+function legacyTopicSlug(topic: string): string {
     return topic.toLowerCase().replace(/\s+/g, '_').slice(0, 50)
 }
 
 /**
- * Save the tree to localStorage
+ * Save the tree to localStorage under the given id. `meta` carries fields
+ * we need to relist the map later (framework + display title); both
+ * optional so callers that don't yet know either can keep saving.
  */
-export function saveTree(topic: string, rootNode: MindmapNode): void {
-    if (typeof window === 'undefined') return
+export function saveTree(
+    id: string,
+    rootNode: MindmapNode,
+    meta?: { frameworkId?: string; topic?: string },
+): void {
+    if (typeof window === 'undefined' || !id) return
 
     try {
-        const key = TREE_CACHE_PREFIX + hashTopic(topic)
+        const key = TREE_CACHE_PREFIX + id
+        // Preserve `createdAt` across updates so the recent-maps UI can
+        // distinguish "first written" from "last touched". Pull existing
+        // meta to avoid stomping a frameworkId we knew on previous writes.
+        const existingRaw = localStorage.getItem(key)
+        let createdAt = Date.now()
+        let prevFramework: string | undefined
+        let prevTopic: string | undefined
+        if (existingRaw) {
+            try {
+                const prev = JSON.parse(existingRaw) as Partial<TreeCacheEntry>
+                if (typeof prev.createdAt === 'number') createdAt = prev.createdAt
+                if (typeof prev.frameworkId === 'string') prevFramework = prev.frameworkId
+                if (typeof prev.topic === 'string') prevTopic = prev.topic
+            } catch {
+                // bad JSON → just overwrite
+            }
+        }
         const entry: TreeCacheEntry = {
             rootNode,
-            createdAt: Date.now(),
-            lastUpdated: Date.now()
+            createdAt,
+            lastUpdated: Date.now(),
+            frameworkId: meta?.frameworkId ?? prevFramework,
+            topic: meta?.topic ?? prevTopic ?? rootNode.label,
         }
         localStorage.setItem(key, JSON.stringify(entry))
     } catch (e) {
@@ -42,18 +106,34 @@ export function saveTree(topic: string, rootNode: MindmapNode): void {
 }
 
 /**
- * Load a tree from localStorage
+ * Load a tree from localStorage. Tries the id-keyed entry first; if it's
+ * missing and a `legacyTopic` is supplied, also tries the pre-id slug so
+ * sessions started on the old URL scheme still recover.
  */
-export function loadTree(topic: string): MindmapNode | null {
+export function loadTree(
+    id: string | null | undefined,
+    legacyTopic?: string,
+): MindmapNode | null {
     if (typeof window === 'undefined') return null
 
     try {
-        const key = TREE_CACHE_PREFIX + hashTopic(topic)
-        const stored = localStorage.getItem(key)
-        if (!stored) return null
-
-        const entry: TreeCacheEntry = JSON.parse(stored)
-        return entry.rootNode
+        if (id) {
+            const idKey = TREE_CACHE_PREFIX + id
+            const stored = localStorage.getItem(idKey)
+            if (stored) {
+                const entry: TreeCacheEntry = JSON.parse(stored)
+                return entry.rootNode
+            }
+        }
+        if (legacyTopic) {
+            const legacyKey = TREE_CACHE_PREFIX + legacyTopicSlug(legacyTopic)
+            const stored = localStorage.getItem(legacyKey)
+            if (stored) {
+                const entry: TreeCacheEntry = JSON.parse(stored)
+                return entry.rootNode
+            }
+        }
+        return null
     } catch (e) {
         console.warn('Tree cache load failed:', e)
         return null
@@ -61,13 +141,57 @@ export function loadTree(topic: string): MindmapNode | null {
 }
 
 /**
- * Clear a specific tree from cache
+ * Clear a specific tree from cache. Accepts either the new id or, for
+ * cleanup of legacy entries, a topic string.
  */
-export function clearTree(topic: string): void {
-    if (typeof window === 'undefined') return
+export function clearTree(idOrTopic: string): void {
+    if (typeof window === 'undefined' || !idOrTopic) return
+    // Try both forms — clearing by id is the common path; topic clears
+    // legacy entries that pre-date the id migration.
+    localStorage.removeItem(TREE_CACHE_PREFIX + idOrTopic)
+    localStorage.removeItem(TREE_CACHE_PREFIX + legacyTopicSlug(idOrTopic))
+}
 
-    const key = TREE_CACHE_PREFIX + hashTopic(topic)
-    localStorage.removeItem(key)
+/**
+ * Scan localStorage and return all stored mindmaps, newest first.
+ *
+ * Skips entries with an empty/blank title — those are typically the seed
+ * tree from "자유롭게 시작" that the user never interacted with, and
+ * showing them just clutters the home page list.
+ */
+export function listRecentMaps(): RecentMapEntry[] {
+    if (typeof window === 'undefined') return []
+
+    const out: RecentMapEntry[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i)
+        if (!key?.startsWith(TREE_CACHE_PREFIX)) continue
+        const id = key.slice(TREE_CACHE_PREFIX.length)
+        // Skip the legacy slug entries — they share the same prefix but
+        // their "id" is a topic slug, which won't round-trip via ?id=.
+        if (id.includes('_')) continue
+
+        const raw = localStorage.getItem(key)
+        if (!raw) continue
+        try {
+            const entry = JSON.parse(raw) as Partial<TreeCacheEntry>
+            if (!entry.rootNode) continue
+            const title = (entry.topic ?? entry.rootNode.label ?? '').trim()
+            if (!title) continue
+            out.push({
+                id,
+                title,
+                lastUpdated: typeof entry.lastUpdated === 'number'
+                    ? entry.lastUpdated
+                    : (entry.createdAt ?? 0),
+                nodeCount: calculateTreeMetadata(entry.rootNode).totalNodes,
+                frameworkId: entry.frameworkId ?? 'LOGIC',
+            })
+        } catch {
+            // bad JSON → ignore
+        }
+    }
+    return out.sort((a, b) => b.lastUpdated - a.lastUpdated)
 }
 
 /**

--- a/lib/tree-cache.ts
+++ b/lib/tree-cache.ts
@@ -56,6 +56,26 @@ export function generateMindmapId(): string {
     return Math.random().toString(16).slice(2, 14).padEnd(12, '0')
 }
 
+/**
+ * Stable 8-hex hash of an arbitrary string. Used to derive a collision-
+ * resistant id for legacy `?topic=` URL fallbacks — slicing the topic's
+ * first 8 chars (the previous approach) collided whenever two topics
+ * shared a prefix.
+ */
+function stableShortHash(s: string): string {
+    // djb2 variant — deterministic, no crypto needed
+    let h = 5381
+    for (let i = 0; i < s.length; i++) {
+        h = ((h << 5) + h + s.charCodeAt(i)) | 0
+    }
+    return (h >>> 0).toString(16).padStart(8, '0').slice(0, 8)
+}
+
+/** Build a stable id for a legacy `?topic=` URL — e.g. `legacy-a3f9b2c1`. */
+export function legacyIdFromTopic(topic: string): string {
+    return `legacy-${stableShortHash(topic)}`
+}
+
 /** Legacy slug — only used for back-compat lookups, never for new writes. */
 function legacyTopicSlug(topic: string): string {
     return topic.toLowerCase().replace(/\s+/g, '_').slice(0, 50)
@@ -167,9 +187,11 @@ export function listRecentMaps(): RecentMapEntry[] {
         const key = localStorage.key(i)
         if (!key?.startsWith(TREE_CACHE_PREFIX)) continue
         const id = key.slice(TREE_CACHE_PREFIX.length)
-        // Skip the legacy slug entries — they share the same prefix but
-        // their "id" is a topic slug, which won't round-trip via ?id=.
-        if (id.includes('_')) continue
+        // Only include id-keyed entries (new 12-hex format or the
+        // `legacy-XXXXXXXX` shape produced by legacyIdFromTopic). Old
+        // slug-keyed entries are excluded — their "id" is a topic slug
+        // that doesn't round-trip via `?id=`.
+        if (!/^(?:[0-9a-f]{12}|legacy-[0-9a-f]{8})$/.test(id)) continue
 
         const raw = localStorage.getItem(key)
         if (!raw) continue

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next"
 
+const LOCAL_BACKEND_URL =
+    process.env.LOCAL_BACKEND_URL || "http://localhost:8000"
+
 const nextConfig: NextConfig = {
     reactStrictMode: true,
     poweredByHeader: false,
@@ -10,6 +13,21 @@ const nextConfig: NextConfig = {
             "@hugeicons/react",
             "framer-motion",
         ],
+    },
+    /**
+     * Dev-only proxy: forward `/api/*` to the local FastAPI server so the
+     * frontend can keep calling same-origin paths during development —
+     * matching how Vercel rewrites them in production. No-op in build /
+     * production (Vercel's `rewrites` in vercel.json takes over there).
+     */
+    async rewrites() {
+        if (process.env.NODE_ENV !== "development") return []
+        return [
+            {
+                source: "/api/:path*",
+                destination: `${LOCAL_BACKEND_URL}/api/:path*`,
+            },
+        ]
     },
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
+    "dev:web": "next dev -p 3001",
+    "dev:api": "uvicorn api.index:app --reload --port 8000",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -17,8 +17,24 @@ interface MindmapStore {
     currentNode: MindmapNode | null
     nodeHistory: MindmapNode[]
     contextPath: string[]
-    /** Topic key used to persist the tree to tree-cache. Set when the map page mounts. */
+    /**
+     * Random short id (12 hex). Used as the tree-cache key and the URL's
+     * `?id=`. Decouples persistence from the topic string, which can be
+     * long Korean text or contain URL-unsafe characters.
+     */
+    mindmapId: string | null
+    /**
+     * Display-only topic. Mirrors `rootNode.label` after edits, so the
+     * report panel and other consumers always see the user-edited title.
+     * No longer used as a cache key.
+     */
     topic: string | null
+    /**
+     * Framework key (BMC, LEAN, LOGIC, …). Persisted alongside the tree
+     * so the recent-maps list on the home page can re-open the map with
+     * the correct `?framework=` instead of guessing.
+     */
+    frameworkId: string | null
 
     // Delete/Undo State
     deletedNodeBackup: DeletedNodeBackup | null
@@ -30,7 +46,9 @@ interface MindmapStore {
     isLoading: boolean
 
     // Actions
+    setMindmapId: (id: string | null) => void
     setTopic: (topic: string | null) => void
+    setFrameworkId: (id: string | null) => void
     setRootNode: (node: MindmapNode) => void
     setCurrentNode: (node: MindmapNode) => void
     navigateTo: (node: MindmapNode) => void
@@ -55,7 +73,9 @@ const initialState = {
     currentNode: null,
     nodeHistory: [],
     contextPath: [],
+    mindmapId: null as string | null,
     topic: null as string | null,
+    frameworkId: null as string | null,
     deletedNodeBackup: null as DeletedNodeBackup | null,
     viewMode: 'mindmap' as ViewMode,
     expandingNodeId: null,
@@ -63,11 +83,22 @@ const initialState = {
     isLoading: false,
 }
 
-/** Internal: persist the current root tree to localStorage if a topic is set. */
-function persistTree(topic: string | null, rootNode: MindmapNode | null) {
-    if (!topic || !rootNode) return
+/**
+ * Internal: persist the current root tree to localStorage under the id,
+ * along with the framework + topic so the recent-maps list can rebuild
+ * the URL when the user re-opens it.
+ */
+function persistTree(
+    id: string | null,
+    rootNode: MindmapNode | null,
+    meta?: { frameworkId?: string | null; topic?: string | null },
+) {
+    if (!id || !rootNode) return
     try {
-        saveTree(topic, rootNode)
+        saveTree(id, rootNode, {
+            frameworkId: meta?.frameworkId ?? undefined,
+            topic: meta?.topic ?? undefined,
+        })
     } catch {
         // saveTree already logs; swallow to keep store mutations resilient
     }
@@ -76,16 +107,25 @@ function persistTree(topic: string | null, rootNode: MindmapNode | null) {
 export const useMindmapStore = create<MindmapStore>((set, get) => ({
     ...initialState,
 
+    setMindmapId: (mindmapId) => set({ mindmapId }),
     setTopic: (topic) => set({ topic }),
+    setFrameworkId: (frameworkId) => set({ frameworkId }),
 
     setRootNode: (node) => {
+        const nextTopic = node.label || get().topic
         set({
             rootNode: node,
             currentNode: node,
+            // Keep `topic` in sync with the root label so the report panel /
+            // any other reader sees the latest user-edited title.
+            topic: nextTopic,
             nodeHistory: [],
-            contextPath: []
+            contextPath: [],
         })
-        persistTree(get().topic, node)
+        persistTree(get().mindmapId, node, {
+            frameworkId: get().frameworkId,
+            topic: nextTopic,
+        })
     },
 
     setCurrentNode: (node) => set({ currentNode: node }),
@@ -155,7 +195,7 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
     setLoading: (loading) => set({ isLoading: loading }),
 
     expandNode: (nodeId, children) => {
-        const { rootNode, currentNode, topic } = get()
+        const { rootNode, currentNode, mindmapId, frameworkId, topic } = get()
         if (!rootNode || !currentNode) return
 
         // Recursively update node with children
@@ -177,11 +217,11 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
             currentNode: updatedCurrent,
             expandingNodeId: null
         })
-        persistTree(topic, updatedRoot)
+        persistTree(mindmapId, updatedRoot, { frameworkId, topic })
     },
 
     addChildNode: (parentId) => {
-        const { rootNode, currentNode, topic } = get()
+        const { rootNode, currentNode, mindmapId, frameworkId, topic } = get()
         if (!rootNode) return null
 
         // 새 노드 ID 생성 (UUID 형식)
@@ -219,13 +259,13 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
             currentNode: updatedCurrent,
             editingNodeId: newNodeId  // 새 노드를 편집 모드로 설정
         })
-        persistTree(topic, updatedRoot)
+        persistTree(mindmapId, updatedRoot, { frameworkId, topic })
 
         return newNode
     },
 
     updateNodeLabel: (nodeId, label) => {
-        const { rootNode, currentNode, topic } = get()
+        const { rootNode, currentNode, mindmapId, frameworkId, topic } = get()
         if (!rootNode) return
 
         const updateLabel = (node: MindmapNode): MindmapNode => {
@@ -242,16 +282,21 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
         const updatedRoot = updateLabel(rootNode)
         const updatedCurrent = currentNode ? updateLabel(currentNode) : null
 
+        // If the user just edited the root label, mirror it into `topic`
+        // so the report panel and any other reader sees the new title.
+        const isRootEdit = rootNode.id === nodeId
+        const nextTopic = isRootEdit ? label : topic
         set({
             rootNode: updatedRoot,
             currentNode: updatedCurrent,
-            editingNodeId: null  // 편집 모드 해제
+            editingNodeId: null,  // 편집 모드 해제
+            ...(isRootEdit ? { topic: label } : {}),
         })
-        persistTree(topic, updatedRoot)
+        persistTree(mindmapId, updatedRoot, { frameworkId, topic: nextTopic })
     },
 
     deleteNode: (nodeId) => {
-        const { rootNode, currentNode, topic } = get()
+        const { rootNode, currentNode, mindmapId, frameworkId, topic } = get()
         if (!rootNode) return false
 
         // Root 노드는 삭제 불가
@@ -299,13 +344,13 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
                 index: nodeIndex
             }
         })
-        persistTree(topic, updatedRoot)
+        persistTree(mindmapId, updatedRoot, { frameworkId, topic })
 
         return true
     },
 
     undoDelete: () => {
-        const { rootNode, deletedNodeBackup, topic } = get()
+        const { rootNode, deletedNodeBackup, mindmapId, frameworkId, topic } = get()
         if (!rootNode || !deletedNodeBackup) return false
 
         const { node, parentId, index } = deletedNodeBackup
@@ -335,7 +380,7 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
             currentNode: restoredRoot,
             deletedNodeBackup: null
         })
-        persistTree(topic, restoredRoot)
+        persistTree(mindmapId, restoredRoot, { frameworkId, topic })
 
         return true
     },


### PR DESCRIPTION
## Summary

- **메인에 "최근 아이디어" 리스트 추가** — localStorage에 자동 저장된 마인드맵을 한눈에 보고, 클릭으로 재진입하거나 휴지통으로 삭제. tree-cache entry에 framework/topic 메타 필드를 추가해서 `?id=&framework=` URL을 정확히 복원
- **홈/캔버스 UI 일괄 다듬기** — 입력 폼 폭 통일(576px), 의도별 카피 재작성(아이디어/문제/선택지/목표 등 핵심 명사 bold), 기획서 작성 확인 다이얼로그(인디고 primary 버튼), 메인으로 다이얼로그 카피를 7-day 안내 + 다운로드 권장으로 정직화
- **저장은 OPML 단일 버튼**으로 통일 — JSON과 동일한 round-trip 정보를 OPML 사용자 attribute(`_*`)에 넣고 `_export_version="1"` 마이그레이션 앵커 추가. 불러오기는 두 포맷 모두 호환
- **API Key 트리거 정렬 fix** — 우하단 라벨이 원형 트리거 정중앙에 정렬되도록 `items-center`
- **로컬 풀스택 dev 흐름 정비** — `next.config.ts`에 dev 전용 `/api/*` → `localhost:8000` 프록시, `npm run dev:web` (3001) / `dev:api` (uvicorn 8000) 별칭 추가. 프로덕션 Vercel rewrite와 동일한 same-origin 흐름

## Test plan

- [ ] 메인 페이지 첫 진입 시 입력창 + 4개 의도 버튼 정상 노출, 입력 폼과 최근 아이디어 리스트가 같은 폭(576px)으로 정렬
- [ ] 마인드맵 작성 후 메인 복귀 → 최근 아이디어에 노출, 클릭하면 동일 framework로 재진입, 휴지통은 AlertDialog로 확인 후 삭제
- [ ] 우상단 다운로드 버튼 → OPML 파일 받아짐. 같은 파일을 불러오기로 다시 임포트하면 트리/topic/framework 모두 복원
- [ ] iOS Safari 26에서 입력창 폼 너비, 최근 아이디어 너비, 모드 버튼 정렬 확인 (250px 이하 viewport에서도 메인 콘텐츠가 잘리지 않음)
- [ ] 우하단 API Key 설정 라벨이 원형 아이콘과 수직 정렬됨
- [ ] 로컬 dev: `npm run dev:api` (8000) + `npm run dev:web` (3001) 두 터미널로 풀스택 작동, 프론트가 `/api/v1/...` 호출 시 백엔드로 프록시

🤖 Generated with [Claude Code](https://claude.com/claude-code)