### PR TITLE
feat(expand): Phase 0 + 1 + 2 + 3.1 — branch-gen redesign + strategy ensemble

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -73,7 +73,15 @@ STAGE_CONFIG = {
     "framework_pick":    {"model": MODEL_LITE,  "temperature": 0.1, "reasoning": "off"},
     "framework_fallback":{"model": MODEL_LITE,  "temperature": 0.1, "reasoning": "off"},
     "generate_l1":       {"model": MODEL_FLASH, "temperature": 0.4, "reasoning": "off"},
+    # Expand stages — depth-aware temperature curve. L1 should produce
+    # structured framework slots (cool, deterministic), L4 should produce
+    # surprising actions (hot, divergent). The bare `"expand"` key remains
+    # as a fallback for callers that don't pass depth.
     "expand":            {"model": MODEL_FLASH, "temperature": 0.6, "reasoning": "off"},
+    "expand_l1":         {"model": MODEL_LITE,  "temperature": 0.20, "reasoning": "low"},
+    "expand_l2":         {"model": MODEL_FLASH, "temperature": 0.45, "reasoning": "off"},
+    "expand_l3":         {"model": MODEL_FLASH, "temperature": 0.65, "reasoning": "off"},
+    "expand_l4":         {"model": MODEL_FLASH, "temperature": 0.85, "reasoning": "off"},
     # Report = two-stage Researcher + Writer (see api/logic/report_generator.py)
     "report_researcher": {"model": MODEL_FLASH, "temperature": 0.2, "reasoning": "off",
                           "use_search": True},

--- a/api/lib/json_utils.py
+++ b/api/lib/json_utils.py
@@ -5,59 +5,52 @@ Handles malformed AI-generated JSON responses.
 
 import json
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 
-def safe_json_parse(json_str: str) -> Dict[str, Any]:
+def safe_json_parse_tracked(json_str: str) -> Tuple[Dict[str, Any], bool]:
     """
-    Parse JSON with automatic error recovery.
-    
-    Handles common AI-generated JSON errors:
-    - Comments (// ... or /* ... */)
-    - Trailing commas
-    - Unquoted keys
-    - Extra text before/after JSON
-    
+    Parse JSON with automatic error recovery, reporting whether recovery
+    was needed.
+
+    Same recovery chain as `safe_json_parse`, but returns a `(data, recovered)`
+    tuple where `recovered` is True iff step 1 (raw json.loads) failed and a
+    later step rescued the parse. Telemetry uses this to track how often we
+    fall through to the recovery path.
+
     Args:
         json_str: JSON string (possibly malformed)
-    
+
     Returns:
-        Parsed dictionary
-    
+        (parsed dict, recovered flag)
+
     Raises:
         ValueError: If all recovery attempts fail
-    
-    Examples:
-        >>> safe_json_parse('{"label": "Test",}')  # trailing comma
-        {'label': 'Test'}
-        
-        >>> safe_json_parse('// comment\\n{"label": "Test"}')  # comment
-        {'label': 'Test'}
     """
-    # Step 1: Standard parsing
+    # Step 1: Standard parsing — clean path
     try:
-        return json.loads(json_str)
+        return json.loads(json_str), False
     except json.JSONDecodeError:
         pass
-    
+
     # Step 2: Remove comments
     try:
         # Single-line comments: // ...
         cleaned = re.sub(r'//.*?$', '', json_str, flags=re.MULTILINE)
         # Multi-line comments: /* ... */
         cleaned = re.sub(r'/\*.*?\*/', '', cleaned, flags=re.DOTALL)
-        return json.loads(cleaned)
+        return json.loads(cleaned), True
     except json.JSONDecodeError:
         pass
-    
+
     # Step 3: Remove trailing commas
     try:
         # Before closing bracket/brace: , }  or  , ]
         cleaned = re.sub(r',(\s*[}\]])', r'\1', json_str)
-        return json.loads(cleaned)
+        return json.loads(cleaned), True
     except json.JSONDecodeError:
         pass
-    
+
     # Step 4: Extract JSON from text
     try:
         # Find first { or [ and last } or ]
@@ -69,25 +62,44 @@ def safe_json_parse(json_str: str) -> Dict[str, Any]:
             (json_str.rfind('}') if '}' in json_str else -1),
             (json_str.rfind(']') if ']' in json_str else -1)
         )
-        
+
         if start < len(json_str) and end > 0:
             extracted = json_str[start:end+1]
-            return json.loads(extracted)
+            return json.loads(extracted), True
     except (json.JSONDecodeError, ValueError):
         pass
-    
+
     # Step 5: Try dirty-json as last resort (optional dependency)
     try:
         import dirty_json
-        return dirty_json.loads(json_str)
+        return dirty_json.loads(json_str), True
     except (ImportError, Exception):
         pass
-    
+
     # All attempts failed
     raise ValueError(
         f"Failed to parse JSON after all recovery attempts. "
         f"First 200 chars: {json_str[:200]}"
     )
+
+
+def safe_json_parse(json_str: str) -> Dict[str, Any]:
+    """
+    Parse JSON with automatic error recovery.
+
+    Backwards-compat wrapper around `safe_json_parse_tracked` that drops the
+    recovery flag. Use the tracked variant when you want telemetry on how
+    often parsing falls into the recovery chain.
+
+    Examples:
+        >>> safe_json_parse('{"label": "Test",}')  # trailing comma
+        {'label': 'Test'}
+
+        >>> safe_json_parse('// comment\\n{"label": "Test"}')  # comment
+        {'label': 'Test'}
+    """
+    data, _ = safe_json_parse_tracked(json_str)
+    return data
 
 
 def extract_number_from_text(text: str) -> int:

--- a/api/logic/expander.py
+++ b/api/logic/expander.py
@@ -16,7 +16,7 @@ from google.genai import types
 
 from config import GEMINI_API_KEY
 from schemas.expand_schema import ExpandRequest, ExpandResponse
-from lib.json_utils import safe_json_parse
+from lib.json_utils import safe_json_parse_tracked
 from lib.gemini_config import build_config, get_model
 
 logger = logging.getLogger(__name__)
@@ -108,7 +108,13 @@ class NodeExpander:
                 request, generate_count, force_logic_tree
             )
 
-            # 5. Call Gemini Flash (model + temperature from STAGE_CONFIG["expand"])
+            # 5. Call Gemini Flash (model + temperature from STAGE_CONFIG["expand"]).
+            #    `seed` (optional) is forwarded to GenerateContentConfig via the
+            #    `**extra` passthrough — None = standard stochastic, integer =
+            #    deterministic for debug/A-B/CI golden-output tests.
+            extra: dict = {}
+            if request.seed is not None:
+                extra["seed"] = request.seed
             response = await client.aio.models.generate_content(
                 model=get_model("expand"),
                 contents=user_contents,
@@ -116,12 +122,13 @@ class NodeExpander:
                     "expand",
                     response_mime_type="application/json",
                     system_instruction=system_instruction,
+                    **extra,
                 ),
             )
 
-            # 6. Parse and validate
+            # 6. Parse and validate (track recovery for telemetry).
             json_str = response.text
-            data = safe_json_parse(json_str)
+            data, parse_recovery = safe_json_parse_tracked(json_str)
             children = data.get("children", [])
 
             # 7. Post-process: adjust count
@@ -142,6 +149,24 @@ class NodeExpander:
 
             # Validate with Pydantic
             validated_result = ExpandResponse.model_validate(data)
+
+            # 9. Telemetry — one structured line per expansion.
+            #    Read by Phase 0 baseline measurement (parse_recovery rate,
+            #    returned/requested ratio, confidence distribution).
+            logger.info(
+                "expand_telemetry depth=%d framework=%s used=%s requested=%d returned=%d "
+                "confidence=%.2f language=%s parse_recovery=%s seed=%s applied=%s",
+                request.current_depth,
+                request.current_framework_id,
+                ",".join(request.used_frameworks) if request.used_frameworks else "-",
+                generate_count,
+                len(children),
+                validated_result.confidence_score,
+                request.language,
+                parse_recovery,
+                request.seed if request.seed is not None else "-",
+                validated_result.applied_framework_id or "-",
+            )
 
             return validated_result.model_dump()
 

--- a/api/logic/expander.py
+++ b/api/logic/expander.py
@@ -14,8 +14,8 @@ from typing import Optional
 from google import genai
 from google.genai import types
 
-from config import GEMINI_API_KEY
-from schemas.expand_schema import ExpandRequest, ExpandResponse
+from config import GEMINI_API_KEY, STAGE_CONFIG
+from schemas.expand_schema import ExpandRequest, ExpandResponse, ExpandResponseSchema
 from lib.json_utils import safe_json_parse_tracked
 from lib.gemini_config import build_config, get_model
 
@@ -108,36 +108,90 @@ class NodeExpander:
                 request, generate_count, force_logic_tree
             )
 
-            # 5. Call Gemini Flash (model + temperature from STAGE_CONFIG["expand"]).
-            #    `seed` (optional) is forwarded to GenerateContentConfig via the
-            #    `**extra` passthrough — None = standard stochastic, integer =
-            #    deterministic for debug/A-B/CI golden-output tests.
+            # 5. Resolve the per-depth stage (Phase 1 depth curve).
+            #    `expand_l1..l4` exists; otherwise fall back to bare "expand".
+            #    The child layer = current_depth + 1 (L0 root expanding into L1).
+            target_layer = min(max(request.current_depth + 1, 1), 4)
+            stage_key = f"expand_l{target_layer}"
+            if stage_key not in STAGE_CONFIG:
+                stage_key = "expand"
+
+            # 6. Call Gemini. `seed` (optional) is forwarded for repro;
+            #    L3+ adds anti-repetition penalties so siblings don't all
+            #    start with the same lead noun ("효율적인 X / 효율적인 Y").
+            #    `response_schema` enforces structured output at the model
+            #    level, eliminating the JSON recovery chain in the happy
+            #    path — but we keep mime + recovery as defense-in-depth.
             extra: dict = {}
             if request.seed is not None:
                 extra["seed"] = request.seed
-            response = await client.aio.models.generate_content(
-                model=get_model("expand"),
-                contents=user_contents,
-                config=build_config(
-                    "expand",
-                    response_mime_type="application/json",
-                    system_instruction=system_instruction,
-                    **extra,
-                ),
-            )
+            if target_layer >= 3:
+                extra["presence_penalty"] = 0.4
+                extra["frequency_penalty"] = 0.3
+
+            try:
+                response = await client.aio.models.generate_content(
+                    model=get_model(stage_key),
+                    contents=user_contents,
+                    config=build_config(
+                        stage_key,
+                        response_mime_type="application/json",
+                        system_instruction=system_instruction,
+                        response_schema=ExpandResponseSchema,
+                        **extra,
+                    ),
+                )
+            except (TypeError, ValueError) as schema_err:
+                # Some google-genai versions reject Optional[...] in
+                # response_schema. Fall back to mime-only — the recovery
+                # chain handles malformed output, and telemetry will
+                # surface the regression so we can fix the schema.
+                logger.warning(
+                    "response_schema rejected (%s) — falling back to mime-only",
+                    schema_err,
+                )
+                response = await client.aio.models.generate_content(
+                    model=get_model(stage_key),
+                    contents=user_contents,
+                    config=build_config(
+                        stage_key,
+                        response_mime_type="application/json",
+                        system_instruction=system_instruction,
+                        **extra,
+                    ),
+                )
 
             # 6. Parse and validate (track recovery for telemetry).
             json_str = response.text
             data, parse_recovery = safe_json_parse_tracked(json_str)
             children = data.get("children", [])
 
-            # 7. Post-process: adjust count
+            # 7. Post-process:
+            #    (a) cap count, (b) drop dupes vs existing children, (c) drop
+            #    same-call dupes, (d) score importance, (e) regenerate IDs.
             children = self._adjust_children_count(
                 children,
                 generate_count,
                 request,
-                force_logic_tree
+                force_logic_tree,
             )
+            children = self._dedupe_children(children, request.existing_children or [])
+
+            applied_framework_id = data.get("applied_framework_id")
+            for idx, child in enumerate(children):
+                # Honor model-supplied importance only when it's a clear
+                # signal (1, 3, 4, 5). Otherwise (None or default 2) compute
+                # heuristically so the frontend has a real distribution to
+                # render with.
+                model_imp = child.get("importance")
+                if model_imp not in (1, 3, 4, 5):
+                    child["importance"] = self._score_importance(
+                        child,
+                        idx,
+                        request.current_depth,
+                        applied_framework_id,
+                    )
+
             data["children"] = children
 
             # 8. Regenerate unique IDs (ASCII-safe to keep React Flow happy)
@@ -151,18 +205,21 @@ class NodeExpander:
             validated_result = ExpandResponse.model_validate(data)
 
             # 9. Telemetry — one structured line per expansion.
-            #    Read by Phase 0 baseline measurement (parse_recovery rate,
-            #    returned/requested ratio, confidence distribution).
+            #    Phase 1 adds stage + intent + dna flags.
             logger.info(
-                "expand_telemetry depth=%d framework=%s used=%s requested=%d returned=%d "
-                "confidence=%.2f language=%s parse_recovery=%s seed=%s applied=%s",
+                "expand_telemetry depth=%d stage=%s framework=%s used=%s "
+                "requested=%d returned=%d confidence=%.2f language=%s "
+                "intent=%s dna=%s parse_recovery=%s seed=%s applied=%s",
                 request.current_depth,
+                stage_key,
                 request.current_framework_id,
                 ",".join(request.used_frameworks) if request.used_frameworks else "-",
                 generate_count,
                 len(children),
                 validated_result.confidence_score,
                 request.language,
+                request.intent_mode or "-",
+                "y" if request.context_vector else "n",
                 parse_recovery,
                 request.seed if request.seed is not None else "-",
                 validated_result.applied_framework_id or "-",
@@ -275,6 +332,49 @@ Rule: {layer_def.get('rule', 'Generate relevant sub-items.')}
 Format: {layer_def.get('format', 'Short phrases')}
 """
 
+        # Business DNA — when smart-classify produced a context_vector, inject
+        # it so children are grounded in THIS user's specific business rather
+        # than generic framework boilerplate.
+        dna_section = ""
+        if request.context_vector:
+            cv = request.context_vector
+            parts = []
+            if cv.summary:
+                parts.append(f"- Identity: {cv.summary}")
+            if cv.target:
+                parts.append(f"- Target: {cv.target}")
+            if cv.edge:
+                parts.append(f"- Edge: {cv.edge}")
+            if cv.objective:
+                parts.append(f"- Objective: {cv.objective}")
+            if parts:
+                dna_section = (
+                    "\n[BUSINESS DNA]\n"
+                    + "\n".join(parts)
+                    + "\nUse these to make children specific to THIS business, not generic.\n"
+                )
+
+        # Intent mode — slight tone-shift hint. Optional and cheap.
+        intent_section = ""
+        if request.intent_mode:
+            tone_map = {
+                "creation": "User is in CREATION mode — favor generative, opportunity-shaped children.",
+                "diagnosis": "User is in DIAGNOSIS mode — favor causal, problem-decomposing children.",
+                "choice": "User is in CHOICE mode — favor evaluative, comparison-shaped children.",
+                "strategy": "User is in STRATEGY mode — favor goal/plan/checkpoint-shaped children.",
+            }
+            intent_section = f"\n[INTENT]\n{tone_map.get(request.intent_mode, request.intent_mode)}\n"
+
+        # Anti-repetition nudge for L3+ — pairs with presence/frequency
+        # penalties; cheap belt-and-braces against same-leading-word siblings.
+        anti_rep_section = ""
+        if request.current_depth + 1 >= 3:
+            anti_rep_section = (
+                "\n[DIVERSITY]\n"
+                "Each child MUST start with a different first word from its siblings. "
+                "Avoid repeating the same leading noun across children.\n"
+            )
+
         # Build force instruction
         force_instruction = self._build_force_instruction(
             request.force_framework,
@@ -285,7 +385,8 @@ Format: {layer_def.get('format', 'Short phrases')}
         system_instruction = (
             f"{self.system_prompt}\n\n"
             f"[TARGET LANGUAGE]\n{request.language}\n"
-            f"{sibling_section}{parent_sibling_section}{existing_section}{layer_section}\n"
+            f"{sibling_section}{parent_sibling_section}{existing_section}"
+            f"{dna_section}{intent_section}{layer_section}{anti_rep_section}\n"
             "[CONSTRAINTS]\n"
             f"- Generate exactly {generate_count} children (no more, no less)\n"
             f"- Current Framework: {request.current_framework_id}\n"
@@ -326,6 +427,64 @@ Format: {layer_def.get('format', 'Short phrases')}
 
         logger.info("Insufficient children (%d/%d) — using what AI returned", len(children), target_count)
         return children
+
+    @staticmethod
+    def _normalize_label(label: str) -> str:
+        """Lowercased, punctuation/whitespace-stripped form for dedup compare."""
+        return re.sub(r"[\s\W_]+", "", (label or "").lower())
+
+    def _dedupe_children(self, children: list, existing_labels: list) -> list:
+        """
+        Drop children whose normalized label collides with an existing
+        sibling (add-mode dedup) or with another child in the same response
+        (intra-call dedup). Prompt asks the model not to duplicate, but the
+        instruction is fragile — this post-pass makes it actually true.
+        """
+        seen = {self._normalize_label(s) for s in existing_labels if s}
+        out: list = []
+        dropped = 0
+        for child in children:
+            key = self._normalize_label(child.get("label", ""))
+            if not key:
+                # Unlabeled children are useless; drop.
+                dropped += 1
+                continue
+            if key in seen:
+                dropped += 1
+                continue
+            seen.add(key)
+            out.append(child)
+        if dropped:
+            logger.info("Dedup dropped %d duplicate child(ren)", dropped)
+        return out
+
+    def _score_importance(
+        self,
+        child: dict,
+        idx: int,
+        current_depth: int,
+        applied_framework_id: Optional[str],
+    ) -> int:
+        """
+        Compute an importance score (1-5) when the model didn't supply a
+        meaningful one. Heuristic only — the goal is "frontend has a real
+        distribution to render with" rather than ground-truth.
+
+        Position bonus: earlier children weight more. Type bonus: framework
+        anchors get a bump. Semantic bonus: finance/risk at shallow depths
+        get a bump. Capped at 4 to keep "5 = critical" reserved for the
+        future quality-rubric pass.
+        """
+        score = 3 if idx <= 1 else 2
+
+        if applied_framework_id and child.get("type") == "framework_branch":
+            score += 1
+
+        sem = child.get("semantic_type")
+        if sem in ("finance", "risk") and current_depth <= 2:
+            score += 1
+
+        return max(1, min(4, score))
     
     def _check_nesting_limit(self, used_frameworks: list) -> bool:
         """

--- a/api/logic/expander.py
+++ b/api/logic/expander.py
@@ -6,6 +6,7 @@ Enhanced with Layer Definition, Sibling Context, and Smart Count Control.
 
 import json
 import logging
+import math
 import random
 import re
 from uuid import uuid4
@@ -14,7 +15,7 @@ from typing import Optional
 from google import genai
 from google.genai import types
 
-from config import GEMINI_API_KEY, STAGE_CONFIG
+from config import GEMINI_API_KEY, MODEL_PRO, STAGE_CONFIG
 from schemas.expand_schema import ExpandRequest, ExpandResponse, ExpandResponseSchema
 from lib.json_utils import safe_json_parse_tracked
 from lib.gemini_config import build_config, get_model
@@ -30,6 +31,40 @@ MAX_FRAMEWORK_NESTING = 2
 
 # Maximum retry for insufficient children
 MAX_RETRY = 1
+
+
+# Phase 2: user-selected expansion modes. Each maps to a small bundle of
+# parameter overrides + a prompt addon. `default` is a no-op so callers
+# that omit `expansion_mode` get the Phase 1 behavior unchanged.
+_MODE_PROMPT_ADDON = {
+    "diverse": (
+        "\n[MODE: DIVERSE]\n"
+        "Take maximally different angles across children. Each child should "
+        "represent a distinct lens (financial / operational / cultural / "
+        "technical / human). Reject the 2-3 most obvious children any "
+        "consultant would propose first; favor unconventional but relevant "
+        "framings. Anti-pattern: variations of the same noun.\n"
+    ),
+    "deep": (
+        "\n[MODE: DEEP]\n"
+        "Think step-by-step (you have reasoning enabled):\n"
+        "  1. What FUNDAMENTAL question is this node asking?\n"
+        "  2. What 2-3 deepest principles govern this domain?\n"
+        "  3. What 2nd-order effects emerge from each candidate child?\n"
+        "  4. Eliminate children whose 2nd-order effects are weak.\n"
+        "Output only the children that survived the depth check.\n"
+    ),
+    "mece": (
+        "\n[MODE: MECE-STRICT]\n"
+        "Children MUST be Mutually Exclusive AND Collectively Exhaustive.\n"
+        "Before responding, internally verify:\n"
+        "  1. No two children share meaningful semantic overlap (must be NO).\n"
+        "  2. Together they cover all major dimensions of the parent (YES).\n"
+        "  3. All children are at the SAME abstraction level (YES).\n"
+        "If you cannot satisfy all three with the requested count, return "
+        "fewer children and set expansion_mode='semi_structured'.\n"
+    ),
+}
 
 
 class NodeExpander:
@@ -101,14 +136,7 @@ class NodeExpander:
             # 3. Check framework nesting limit
             force_logic_tree = self._check_nesting_limit(request.used_frameworks)
 
-            # 4. Build prompt — operator instructions go to system_instruction,
-            #    untrusted user-supplied fields are confined to the user contents
-            #    block to mitigate prompt injection.
-            system_instruction, user_contents = self._build_prompts(
-                request, generate_count, force_logic_tree
-            )
-
-            # 5. Resolve the per-depth stage (Phase 1 depth curve).
+            # 4. Resolve the per-depth stage (Phase 1 depth curve).
             #    `expand_l1..l4` exists; otherwise fall back to bare "expand".
             #    The child layer = current_depth + 1 (L0 root expanding into L1).
             target_layer = min(max(request.current_depth + 1, 1), 4)
@@ -116,22 +144,61 @@ class NodeExpander:
             if stage_key not in STAGE_CONFIG:
                 stage_key = "expand"
 
+            # 5. Phase 2: apply user-selected expansion mode overrides.
+            #     `default` is a no-op; the others tweak temperature/top_p/
+            #     model + bump or shrink the count + append a prompt block.
+            mode = request.expansion_mode or "default"
+            base_temp = STAGE_CONFIG[stage_key]["temperature"]
+            max_children = self._get_layer_definition(request.current_depth).get("max_children", 5)
+
+            mode_extra: dict = {}
+            mode_model_override: Optional[str] = None
+            adjusted_count = generate_count
+
+            if mode == "diverse":
+                mode_extra["temperature_override"] = min(0.95, base_temp + 0.2)
+                mode_extra["top_p"] = 0.97
+                # Ask the model for ~1.5x children so the post-pass dedupe
+                # has headroom to cut overlaps and still hit the floor.
+                adjusted_count = min(max_children, math.ceil(generate_count * 1.5))
+            elif mode == "deep":
+                # Pro + HIGH reasoning; cool the temperature so reasoning
+                # tokens dominate sampling rather than divergence.
+                mode_model_override = MODEL_PRO
+                mode_extra["temperature_override"] = max(0.2, base_temp - 0.2)
+                mode_extra["thinking_config"] = types.ThinkingConfig(
+                    thinking_level=types.ThinkingLevel.HIGH,
+                )
+            elif mode == "mece":
+                mode_extra["temperature_override"] = max(0.2, base_temp - 0.2)
+                mode_extra["top_p"] = 0.85
+
+            # Build prompts with the (possibly bumped) count + mode addon.
+            #    Operator instructions go to system_instruction, untrusted
+            #    user-supplied fields are confined to user_contents to
+            #    mitigate prompt injection.
+            system_instruction, user_contents = self._build_prompts(
+                request, adjusted_count, force_logic_tree, mode=mode,
+            )
+
             # 6. Call Gemini. `seed` (optional) is forwarded for repro;
             #    L3+ adds anti-repetition penalties so siblings don't all
             #    start with the same lead noun ("효율적인 X / 효율적인 Y").
             #    `response_schema` enforces structured output at the model
             #    level, eliminating the JSON recovery chain in the happy
             #    path — but we keep mime + recovery as defense-in-depth.
-            extra: dict = {}
+            extra: dict = dict(mode_extra)
             if request.seed is not None:
                 extra["seed"] = request.seed
             if target_layer >= 3:
-                extra["presence_penalty"] = 0.4
-                extra["frequency_penalty"] = 0.3
+                # Don't clobber a mode-set top_p with the L3+ default.
+                extra.setdefault("presence_penalty", 0.4)
+                extra.setdefault("frequency_penalty", 0.3)
 
+            call_model = mode_model_override or get_model(stage_key)
             try:
                 response = await client.aio.models.generate_content(
-                    model=get_model(stage_key),
+                    model=call_model,
                     contents=user_contents,
                     config=build_config(
                         stage_key,
@@ -151,7 +218,7 @@ class NodeExpander:
                     schema_err,
                 )
                 response = await client.aio.models.generate_content(
-                    model=get_model(stage_key),
+                    model=call_model,
                     contents=user_contents,
                     config=build_config(
                         stage_key,
@@ -160,6 +227,11 @@ class NodeExpander:
                         **extra,
                     ),
                 )
+
+            # Telemetry-friendly: track the actual count we asked for after
+            # mode adjustment (different from `generate_count` only in
+            # diverse mode).
+            generate_count = adjusted_count
 
             # 6. Parse and validate (track recovery for telemetry).
             json_str = response.text
@@ -207,11 +279,12 @@ class NodeExpander:
             # 9. Telemetry — one structured line per expansion.
             #    Phase 1 adds stage + intent + dna flags.
             logger.info(
-                "expand_telemetry depth=%d stage=%s framework=%s used=%s "
+                "expand_telemetry depth=%d stage=%s mode=%s framework=%s used=%s "
                 "requested=%d returned=%d confidence=%.2f language=%s "
                 "intent=%s dna=%s parse_recovery=%s seed=%s applied=%s",
                 request.current_depth,
                 stage_key,
+                mode,
                 request.current_framework_id,
                 ",".join(request.used_frameworks) if request.used_frameworks else "-",
                 generate_count,
@@ -278,7 +351,8 @@ class NodeExpander:
         self,
         request: ExpandRequest,
         generate_count: int,
-        force_logic_tree: bool
+        force_logic_tree: bool,
+        mode: str = "default",
     ) -> tuple[str, str]:
         """
         Build (system_instruction, user_contents) pair.
@@ -311,15 +385,21 @@ The parent node's siblings (for broader context):
 Focus: This expansion is specifically about the target node, not about the above siblings.
 """
 
-        # Build existing children context (for add mode)
+        # Build existing children context (for add mode). When `existing_children`
+        # is non-empty we strengthen the section into [EXPLICIT NEW ANGLE] —
+        # the user is explicitly asking for "다른 관점으로 추가" so the model
+        # should pivot to a different lens, not just dedupe by string.
         existing_section = ""
         if request.existing_children:
             existing_list = "\n".join([f"- {c}" for c in request.existing_children])
             existing_section = f"""
-[EXISTING CHILDREN - DO NOT DUPLICATE]
-The following children already exist:
+[EXPLICIT NEW ANGLE — ADD MODE]
+The user already saw these children of the target node:
 {existing_list}
-Generate NEW children that are DIFFERENT from the above.
+Now generate children that approach the target from a DIFFERENT lens than
+the above. Examples of angle shifts: financial → operational, internal →
+external, customer → competitor, short-term → long-term. Children must be
+non-overlapping with the existing list AND non-overlapping with each other.
 """
 
         # Build layer definition section
@@ -375,6 +455,9 @@ Format: {layer_def.get('format', 'Short phrases')}
                 "Avoid repeating the same leading noun across children.\n"
             )
 
+        # Phase 2: user-selected expansion-mode addon.
+        mode_section = _MODE_PROMPT_ADDON.get(mode, "")
+
         # Build force instruction
         force_instruction = self._build_force_instruction(
             request.force_framework,
@@ -386,7 +469,8 @@ Format: {layer_def.get('format', 'Short phrases')}
             f"{self.system_prompt}\n\n"
             f"[TARGET LANGUAGE]\n{request.language}\n"
             f"{sibling_section}{parent_sibling_section}{existing_section}"
-            f"{dna_section}{intent_section}{layer_section}{anti_rep_section}\n"
+            f"{dna_section}{intent_section}{layer_section}{anti_rep_section}"
+            f"{mode_section}\n"
             "[CONSTRAINTS]\n"
             f"- Generate exactly {generate_count} children (no more, no less)\n"
             f"- Current Framework: {request.current_framework_id}\n"

--- a/api/logic/expander.py
+++ b/api/logic/expander.py
@@ -2,8 +2,13 @@
 Node Expander using Gemini Flash.
 Dynamically expands nodes based on context and employs hybrid expansion strategy.
 Enhanced with Layer Definition, Sibling Context, and Smart Count Control.
+
+Phase 3 architecture: `expand_node` resolves a `GenerationStrategy` from the
+request's `expansion_mode`, fans variants out in parallel, then aggregates.
+The single-call legacy path is the `default` strategy (1 balanced variant).
 """
 
+import asyncio
 import json
 import logging
 import math
@@ -15,10 +20,15 @@ from typing import Optional
 from google import genai
 from google.genai import types
 
-from config import GEMINI_API_KEY, MODEL_PRO, STAGE_CONFIG
+from config import GEMINI_API_KEY, MODEL_LITE, STAGE_CONFIG
 from schemas.expand_schema import ExpandRequest, ExpandResponse, ExpandResponseSchema
-from lib.json_utils import safe_json_parse_tracked
+from lib.json_utils import safe_json_parse_tracked, safe_json_parse
 from lib.gemini_config import build_config, get_model
+from logic.strategy_registry import (
+    GenerationStrategy,
+    GenerationVariant,
+    get_strategy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +126,6 @@ class NodeExpander:
         Returns:
             Dictionary containing expansion results
         """
-        response = None
         try:
             client = self._get_client(api_key)
 
@@ -144,117 +153,63 @@ class NodeExpander:
             if stage_key not in STAGE_CONFIG:
                 stage_key = "expand"
 
-            # 5. Phase 2: apply user-selected expansion mode overrides.
-            #     `default` is a no-op; the others tweak temperature/top_p/
-            #     model + bump or shrink the count + append a prompt block.
+            # 5. Phase 3: resolve strategy + fan variants out in parallel.
+            #     `default` strategy = 1 variant (current behavior).
+            #     `diverse` = 3 variants → fuse_dedupe aggregator.
+            #     `deep` = Pro + HIGH reasoning, single variant.
+            #     `mece` = single variant + MECE validator pass.
             mode = request.expansion_mode or "default"
+            strategy = get_strategy(mode)
             base_temp = STAGE_CONFIG[stage_key]["temperature"]
             max_children = self._get_layer_definition(request.current_depth).get("max_children", 5)
 
-            mode_extra: dict = {}
-            mode_model_override: Optional[str] = None
-            adjusted_count = generate_count
-
-            if mode == "diverse":
-                mode_extra["temperature_override"] = min(0.95, base_temp + 0.2)
-                mode_extra["top_p"] = 0.97
-                # Ask the model for ~1.5x children so the post-pass dedupe
-                # has headroom to cut overlaps and still hit the floor.
-                adjusted_count = min(max_children, math.ceil(generate_count * 1.5))
-            elif mode == "deep":
-                # Pro + HIGH reasoning; cool the temperature so reasoning
-                # tokens dominate sampling rather than divergence.
-                mode_model_override = MODEL_PRO
-                mode_extra["temperature_override"] = max(0.2, base_temp - 0.2)
-                mode_extra["thinking_config"] = types.ThinkingConfig(
-                    thinking_level=types.ThinkingLevel.HIGH,
+            # Run variants in parallel. Each returns a `Candidate` dict:
+            #   {label, weight, children: [...], applied_framework_id,
+            #    expansion_mode, confidence_score, alternative_framework,
+            #    parse_recovery: bool}
+            variant_tasks = [
+                self._run_variant(
+                    client=client,
+                    request=request,
+                    variant=variant,
+                    stage_key=stage_key,
+                    base_temp=base_temp,
+                    base_count=generate_count,
+                    max_children=max_children,
+                    target_layer=target_layer,
+                    force_logic_tree=force_logic_tree,
+                    mode=mode,
                 )
-            elif mode == "mece":
-                mode_extra["temperature_override"] = max(0.2, base_temp - 0.2)
-                mode_extra["top_p"] = 0.85
+                for variant in strategy.variants
+            ]
+            candidates = await asyncio.gather(*variant_tasks, return_exceptions=False)
 
-            # Build prompts with the (possibly bumped) count + mode addon.
-            #    Operator instructions go to system_instruction, untrusted
-            #    user-supplied fields are confined to user_contents to
-            #    mitigate prompt injection.
-            system_instruction, user_contents = self._build_prompts(
-                request, adjusted_count, force_logic_tree, mode=mode,
+            # 6. Aggregate variants → single child list at target count.
+            children, agg_meta = self._aggregate_candidates(
+                candidates,
+                target_count=generate_count,
+                existing_labels=request.existing_children or [],
+                aggregator_mode=strategy.aggregator,
             )
 
-            # 6. Call Gemini. `seed` (optional) is forwarded for repro;
-            #    L3+ adds anti-repetition penalties so siblings don't all
-            #    start with the same lead noun ("효율적인 X / 효율적인 Y").
-            #    `response_schema` enforces structured output at the model
-            #    level, eliminating the JSON recovery chain in the happy
-            #    path — but we keep mime + recovery as defense-in-depth.
-            extra: dict = dict(mode_extra)
-            if request.seed is not None:
-                extra["seed"] = request.seed
-            if target_layer >= 3:
-                # Don't clobber a mode-set top_p with the L3+ default.
-                extra.setdefault("presence_penalty", 0.4)
-                extra.setdefault("frequency_penalty", 0.3)
+            # The "winner" candidate's metadata wins for response-level
+            # fields (applied_framework_id, expansion_mode, confidence,
+            # alternative_framework). For best_of_n that's the single
+            # variant's; for fuse_dedupe it's the highest-weighted variant
+            # that contributed.
+            winner = agg_meta["winner"]
+            applied_framework_id = winner.get("applied_framework_id")
+            data: dict = {
+                "children": children,
+                "applied_framework_id": applied_framework_id,
+                "expansion_mode": winner.get("expansion_mode") or "logic_tree",
+                "confidence_score": float(winner.get("confidence_score") or 0.0),
+                "alternative_framework": winner.get("alternative_framework"),
+            }
+            parse_recovery_any = any(c.get("parse_recovery") for c in candidates)
 
-            call_model = mode_model_override or get_model(stage_key)
-            try:
-                response = await client.aio.models.generate_content(
-                    model=call_model,
-                    contents=user_contents,
-                    config=build_config(
-                        stage_key,
-                        response_mime_type="application/json",
-                        system_instruction=system_instruction,
-                        response_schema=ExpandResponseSchema,
-                        **extra,
-                    ),
-                )
-            except (TypeError, ValueError) as schema_err:
-                # Some google-genai versions reject Optional[...] in
-                # response_schema. Fall back to mime-only — the recovery
-                # chain handles malformed output, and telemetry will
-                # surface the regression so we can fix the schema.
-                logger.warning(
-                    "response_schema rejected (%s) — falling back to mime-only",
-                    schema_err,
-                )
-                response = await client.aio.models.generate_content(
-                    model=call_model,
-                    contents=user_contents,
-                    config=build_config(
-                        stage_key,
-                        response_mime_type="application/json",
-                        system_instruction=system_instruction,
-                        **extra,
-                    ),
-                )
-
-            # Telemetry-friendly: track the actual count we asked for after
-            # mode adjustment (different from `generate_count` only in
-            # diverse mode).
-            generate_count = adjusted_count
-
-            # 6. Parse and validate (track recovery for telemetry).
-            json_str = response.text
-            data, parse_recovery = safe_json_parse_tracked(json_str)
-            children = data.get("children", [])
-
-            # 7. Post-process:
-            #    (a) cap count, (b) drop dupes vs existing children, (c) drop
-            #    same-call dupes, (d) score importance, (e) regenerate IDs.
-            children = self._adjust_children_count(
-                children,
-                generate_count,
-                request,
-                force_logic_tree,
-            )
-            children = self._dedupe_children(children, request.existing_children or [])
-
-            applied_framework_id = data.get("applied_framework_id")
+            # 7. Re-score importance after aggregation (positions changed).
             for idx, child in enumerate(children):
-                # Honor model-supplied importance only when it's a clear
-                # signal (1, 3, 4, 5). Otherwise (None or default 2) compute
-                # heuristically so the frontend has a real distribution to
-                # render with.
                 model_imp = child.get("importance")
                 if model_imp not in (1, 3, 4, 5):
                     child["importance"] = self._score_importance(
@@ -264,27 +219,41 @@ class NodeExpander:
                         applied_framework_id,
                     )
 
-            data["children"] = children
-
-            # 8. Regenerate unique IDs (ASCII-safe to keep React Flow happy)
+            # 8. Regenerate unique IDs across the merged set (ASCII-safe).
             ascii_prefix = re.sub(r'[^A-Za-z0-9_]', '', request.target_node_label.replace(" ", "_"))[:12]
             if not ascii_prefix:
                 ascii_prefix = "node"
             for child in children:
                 child["id"] = f"{ascii_prefix}_{uuid4().hex[:8]}"
 
-            # Validate with Pydantic
+            # 9. MECE validator pass (when strategy enables it).
+            #    Phase 3.1 detects + logs; auto-fix lands in 3.2 along with
+            #    the per-pair regenerate loop. For now overlap detection
+            #    surfaces in telemetry so we can measure how often the
+            #    prompt-only mece variant actually delivers MECE.
+            mece_overlap = False
+            if strategy.enable_mece_check and len(children) >= 2:
+                try:
+                    mece_overlap = await self._mece_check(client, children)
+                except Exception as exc:  # noqa: BLE001 — best-effort sec pass
+                    logger.warning("MECE check skipped (%s)", exc)
+
+            # 10. Validate with Pydantic
             validated_result = ExpandResponse.model_validate(data)
 
-            # 9. Telemetry — one structured line per expansion.
-            #    Phase 1 adds stage + intent + dna flags.
+            # 11. Telemetry — one structured line per expansion (Phase 3 adds
+            #     strategy, variants, aggregator, mece_overlap).
             logger.info(
-                "expand_telemetry depth=%d stage=%s mode=%s framework=%s used=%s "
-                "requested=%d returned=%d confidence=%.2f language=%s "
-                "intent=%s dna=%s parse_recovery=%s seed=%s applied=%s",
+                "expand_telemetry depth=%d stage=%s mode=%s strategy=%s variants=%d "
+                "agg=%s framework=%s used=%s requested=%d returned=%d "
+                "confidence=%.2f language=%s intent=%s dna=%s "
+                "parse_recovery=%s mece_overlap=%s seed=%s applied=%s",
                 request.current_depth,
                 stage_key,
                 mode,
+                strategy.name,
+                len(strategy.variants),
+                strategy.aggregator,
                 request.current_framework_id,
                 ",".join(request.used_frameworks) if request.used_frameworks else "-",
                 generate_count,
@@ -293,7 +262,8 @@ class NodeExpander:
                 request.language,
                 request.intent_mode or "-",
                 "y" if request.context_vector else "n",
-                parse_recovery,
+                parse_recovery_any,
+                mece_overlap,
                 request.seed if request.seed is not None else "-",
                 validated_result.applied_framework_id or "-",
             )
@@ -312,7 +282,255 @@ class NodeExpander:
         except Exception as e:
             logger.exception("Expander failed")
             return self._error_response(str(e))
-    
+
+    # ─── Phase 3: variant runner ────────────────────────────────────────────
+
+    async def _run_variant(
+        self,
+        *,
+        client,
+        request: ExpandRequest,
+        variant: GenerationVariant,
+        stage_key: str,
+        base_temp: float,
+        base_count: int,
+        max_children: int,
+        target_layer: int,
+        force_logic_tree: bool,
+        mode: str,
+    ) -> dict:
+        """
+        Run ONE Gemini call with the given variant config and return a
+        candidate dict. Each candidate carries its own children list +
+        metadata; the aggregator merges across variants.
+        """
+        # Resolve the variant's effective config (composed onto the stage).
+        eff_temp = max(0.05, min(0.95, base_temp + variant.temperature_delta))
+        eff_count = min(max_children, max(1, math.ceil(base_count * variant.count_factor)))
+        eff_model = variant.model or get_model(stage_key)
+
+        # Build prompts. The variant's prompt addon overrides the request's
+        # mode addon when set — lets a strategy compose multiple addons
+        # later. For Phase 3.1 they're always the same since each strategy
+        # uses one addon family.
+        addon_mode = variant.prompt_addon_key or mode
+        system_instruction, user_contents = self._build_prompts(
+            request, eff_count, force_logic_tree, mode=addon_mode,
+        )
+
+        # Compose extra config kwargs.
+        extra: dict = {"temperature_override": eff_temp}
+        if variant.top_p is not None:
+            extra["top_p"] = variant.top_p
+        if variant.top_k is not None:
+            extra["top_k"] = variant.top_k
+        if variant.candidate_count > 1:
+            extra["candidate_count"] = variant.candidate_count
+        if variant.presence_penalty is not None:
+            extra["presence_penalty"] = variant.presence_penalty
+        if variant.frequency_penalty is not None:
+            extra["frequency_penalty"] = variant.frequency_penalty
+        if variant.reasoning is not None and variant.reasoning != "off":
+            level = {
+                "minimal": types.ThinkingLevel.MINIMAL,
+                "low": types.ThinkingLevel.LOW,
+                "medium": types.ThinkingLevel.MEDIUM,
+                "high": types.ThinkingLevel.HIGH,
+            }.get(variant.reasoning)
+            if level is not None:
+                extra["thinking_config"] = types.ThinkingConfig(thinking_level=level)
+        if request.seed is not None:
+            extra["seed"] = request.seed
+        # L3+ default anti-rep penalties unless variant already set them.
+        if target_layer >= 3:
+            extra.setdefault("presence_penalty", 0.4)
+            extra.setdefault("frequency_penalty", 0.3)
+
+        # Two-stage call: schema-strict first, mime-only fallback on SDK
+        # rejection. Same pattern as Phase 1 — the recovery chain still
+        # handles malformed output as defense-in-depth.
+        try:
+            response = await client.aio.models.generate_content(
+                model=eff_model,
+                contents=user_contents,
+                config=build_config(
+                    stage_key,
+                    response_mime_type="application/json",
+                    system_instruction=system_instruction,
+                    response_schema=ExpandResponseSchema,
+                    **extra,
+                ),
+            )
+        except (TypeError, ValueError) as schema_err:
+            logger.warning(
+                "[%s] response_schema rejected (%s) — mime-only fallback",
+                variant.label, schema_err,
+            )
+            response = await client.aio.models.generate_content(
+                model=eff_model,
+                contents=user_contents,
+                config=build_config(
+                    stage_key,
+                    response_mime_type="application/json",
+                    system_instruction=system_instruction,
+                    **extra,
+                ),
+            )
+
+        # Parse + per-variant post-process. Importance + final IDs happen
+        # AFTER aggregation (positions / cross-variant uniqueness change).
+        data, parse_recovery = safe_json_parse_tracked(response.text)
+        children = data.get("children", []) or []
+        children = self._adjust_children_count(
+            children, eff_count, request, force_logic_tree,
+        )
+        children = self._dedupe_children(children, request.existing_children or [])
+
+        return {
+            "label": variant.label,
+            "weight": variant.weight,
+            "children": children,
+            "applied_framework_id": data.get("applied_framework_id"),
+            "expansion_mode": data.get("expansion_mode"),
+            "confidence_score": data.get("confidence_score") or 0.0,
+            "alternative_framework": data.get("alternative_framework"),
+            "parse_recovery": parse_recovery,
+            "_eff_temp": eff_temp,
+            "_eff_count": eff_count,
+        }
+
+    # ─── Phase 3: candidate aggregator ──────────────────────────────────────
+
+    def _aggregate_candidates(
+        self,
+        candidates: list,
+        target_count: int,
+        existing_labels: list,
+        aggregator_mode: str,
+    ) -> tuple[list, dict]:
+        """
+        Merge multiple candidates into a single child list at target_count.
+
+        - `best_of_n`: pick the candidate with the highest confidence_score
+          (tiebreak: highest variant weight). Single-variant strategies hit
+          this path trivially.
+        - `fuse_dedupe`: pool every child across candidates, sort by
+          (variant_weight × per-call confidence), then walk the sorted list
+          dropping any whose normalized label collides with one already
+          kept (Jaccard ≥ 0.6 on tokenized labels).
+        - `weighted_blend`: like fuse_dedupe but allocates slots
+          proportionally to variant weights. Phase 3.1 falls back to
+          fuse_dedupe — proper blend lands in 3.2 alongside the registry's
+          devils_advocate strategy.
+
+        Returns `(children, meta)` where `meta["winner"]` is the candidate
+        whose response-level metadata wins (applied_framework_id, etc).
+        """
+        # Filter empty / errored candidates so they don't show up as winners.
+        non_empty = [c for c in candidates if c.get("children")]
+        if not non_empty:
+            return [], {"winner": (candidates[0] if candidates else {})}
+
+        if aggregator_mode == "best_of_n" or len(non_empty) == 1:
+            winner = max(
+                non_empty,
+                key=lambda c: (c.get("confidence_score") or 0.0, c.get("weight", 1.0)),
+            )
+            kept = winner["children"][:target_count]
+            return kept, {"winner": winner}
+
+        # fuse_dedupe / weighted_blend — pool, sort, dedupe.
+        seen = {self._normalize_label(s) for s in existing_labels if s}
+        pool: list[tuple[float, dict, dict]] = []
+        for cand in non_empty:
+            conf = cand.get("confidence_score") or 0.0
+            for child in cand["children"]:
+                rank = (cand.get("weight", 1.0)) * (conf + 0.01)
+                pool.append((rank, child, cand))
+
+        pool.sort(key=lambda t: t[0], reverse=True)
+        kept: list = []
+        kept_cands: dict = {}  # candidate.label → contribution count
+        for _, child, cand in pool:
+            key = self._normalize_label(child.get("label", ""))
+            if not key or key in seen:
+                continue
+            if any(self._jaccard_overlap(key, k) >= 0.6 for k in seen):
+                continue
+            seen.add(key)
+            kept.append(child)
+            kept_cands[cand["label"]] = kept_cands.get(cand["label"], 0) + 1
+            if len(kept) >= target_count:
+                break
+
+        # Winner = candidate that contributed the most kept children
+        # (tiebreak: highest weight). Its response-level metadata wins.
+        if kept_cands:
+            top_label = max(
+                kept_cands.items(),
+                key=lambda kv: (kv[1], next(
+                    (c.get("weight", 1.0) for c in non_empty if c["label"] == kv[0]), 1.0,
+                )),
+            )[0]
+            winner = next(c for c in non_empty if c["label"] == top_label)
+        else:
+            winner = non_empty[0]
+
+        return kept, {"winner": winner}
+
+    @staticmethod
+    def _jaccard_overlap(a: str, b: str) -> float:
+        """Char-bigram Jaccard for short Korean/English labels."""
+        if not a or not b:
+            return 0.0
+        sa = {a[i:i+2] for i in range(max(1, len(a) - 1))}
+        sb = {b[i:i+2] for i in range(max(1, len(b) - 1))}
+        if not sa or not sb:
+            return 0.0
+        inter = sa & sb
+        union = sa | sb
+        return len(inter) / len(union) if union else 0.0
+
+    # ─── Phase 3: MECE validator (detect-only in 3.1) ──────────────────────
+
+    async def _mece_check(self, client, children: list) -> bool:
+        """
+        Cheap Lite call asking "are any two of these children semantically
+        overlapping?". Returns True if overlap detected.
+
+        Phase 3.1 ships detection only; Phase 3.2 will use the returned
+        pair to drop+regenerate the loser. Here we just surface the rate
+        in telemetry so we can measure how often the prompt-only mece
+        variant actually delivers MECE.
+        """
+        labels = [c.get("label", "") for c in children if c.get("label")]
+        if len(labels) < 2:
+            return False
+        prompt = (
+            "You are a strict MECE auditor. Below is a list of sibling "
+            "ideas under one parent topic. Decide whether any TWO of them "
+            "are semantically overlapping (covering the same dimension).\n\n"
+            "Return STRICT JSON of the form:\n"
+            '  {"overlap": true|false}\n\n'
+            "List:\n"
+            + "\n".join(f"{i+1}. {label}" for i, label in enumerate(labels))
+        )
+        try:
+            response = await client.aio.models.generate_content(
+                model=MODEL_LITE,
+                contents=prompt,
+                config=build_config(
+                    "validate_key",  # closest existing stage: Lite + temp 0
+                    response_mime_type="application/json",
+                ),
+            )
+            data = safe_json_parse(response.text or "{}")
+            return bool(data.get("overlap"))
+        except Exception:
+            # Detect-only and best-effort — never let a validator failure
+            # block the actual expansion.
+            return False
+
     def _calculate_generate_count(self, current_depth: int, existing_count: int) -> int:
         """
         Calculate how many children to generate.

--- a/api/logic/strategy_registry.py
+++ b/api/logic/strategy_registry.py
@@ -1,0 +1,181 @@
+"""
+Strategy registry for the branch-generation system (Phase 3).
+
+A `GenerationStrategy` is a recipe for one expansion: 1+ `GenerationVariant`s
+(each = a full Gemini call configuration), an `aggregator` policy for
+merging their outputs, and flags for the optional MECE / quality-rubric
+secondary passes.
+
+This file is the single edit point when adding/tuning a strategy. The
+expander imports `STRATEGIES` and dispatches by name; users select via
+`ExpandRequest.expansion_mode`.
+
+Phase 3 ships 4 strategies (matching the Phase 2 modes):
+
+    default   — 1 variant, balanced. Cheapest, current behavior.
+    diverse   — 3 parallel variants (cool/balanced/hot) → fuse_dedupe
+                aggregator. Cost ~3x, value: angle diversity.
+    deep      — 1 variant on Pro + HIGH reasoning. Cost ~15x — opt-in.
+    mece      — 1 variant + MECE validator pass + 2 retries on overlap.
+
+Future strategies (research, devils_advocate) plug in here without
+expander.py changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+from config import MODEL_FLASH, MODEL_LITE, MODEL_PRO
+
+
+AggregatorMode = Literal["best_of_n", "fuse_dedupe", "weighted_blend"]
+
+
+@dataclass(frozen=True)
+class GenerationVariant:
+    """
+    One Gemini call configuration. Composes ON TOP of the per-depth
+    STAGE_CONFIG so most fields are optional overrides; specify only
+    what diverges from the stage default.
+
+    Notes on fields:
+    - `model`: full model id (`gemini-3-flash-preview`, etc.). When None,
+      use the depth-resolved stage's model.
+    - `temperature_delta`: applied to the stage's base temp; clamped to
+      [0.05, 0.95] before the call. Lets diverse cool/hot variants coexist
+      with the depth-temp curve without hardcoding absolute values.
+    - `reasoning`: when set, overrides STAGE_CONFIG[stage].reasoning. Use
+      "high" for deep variants on Pro.
+    - `count_factor`: multiplier on the layer's count_range result. Diverse
+      asks for 1.5x children so the dedupe survivor pool hits the floor.
+    - `prompt_addon_key`: which `_MODE_PROMPT_ADDON` block (in expander.py)
+      to inject. Mirrors Phase 2's mode → prompt mapping.
+    - `weight`: relative aggregation weight when this variant is in a
+      multi-variant strategy. Higher = more children of this variant
+      survive the dedupe phase.
+    """
+
+    label: str
+    model: Optional[str] = None
+    temperature_delta: float = 0.0
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    reasoning: Optional[str] = None
+    candidate_count: int = 1
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    count_factor: float = 1.0
+    prompt_addon_key: Optional[str] = None
+    weight: float = 1.0
+
+
+@dataclass(frozen=True)
+class GenerationStrategy:
+    """
+    A named recipe: one or more variants + post-processing policy.
+    """
+
+    name: str
+    description: str
+    variants: tuple[GenerationVariant, ...]
+    aggregator: AggregatorMode = "best_of_n"
+    enable_mece_check: bool = False
+    max_mece_retries: int = 0
+    # Phase 3.2 hook — not used yet, reserved.
+    enable_quality_rubric: bool = False
+
+
+# ─── Registered strategies ──────────────────────────────────────────────────
+
+STRATEGIES: dict[str, GenerationStrategy] = {
+    "default": GenerationStrategy(
+        name="default",
+        description="Balanced single Flash call — Phase 0/1/2 baseline.",
+        variants=(
+            GenerationVariant(label="balanced"),
+        ),
+    ),
+
+    "diverse": GenerationStrategy(
+        name="diverse",
+        description="3 parallel variants (cool/balanced/hot) → fuse_dedupe.",
+        variants=(
+            GenerationVariant(
+                label="cool",
+                temperature_delta=-0.15,
+                top_p=0.85,
+                presence_penalty=0.4,
+                frequency_penalty=0.3,
+                prompt_addon_key="diverse",
+                weight=1.0,
+            ),
+            GenerationVariant(
+                label="balanced",
+                temperature_delta=+0.10,
+                top_p=0.92,
+                count_factor=1.3,
+                prompt_addon_key="diverse",
+                weight=1.2,  # the workhorse variant
+            ),
+            GenerationVariant(
+                label="hot",
+                temperature_delta=+0.30,
+                top_p=0.97,
+                count_factor=1.5,
+                presence_penalty=0.6,
+                frequency_penalty=0.5,
+                prompt_addon_key="diverse",
+                weight=0.9,
+            ),
+        ),
+        aggregator="fuse_dedupe",
+    ),
+
+    "deep": GenerationStrategy(
+        name="deep",
+        description="Pro + HIGH reasoning, single thoughtful call.",
+        variants=(
+            GenerationVariant(
+                label="pro_reasoning",
+                model=MODEL_PRO,
+                temperature_delta=-0.20,
+                reasoning="high",
+                prompt_addon_key="deep",
+            ),
+        ),
+    ),
+
+    "mece": GenerationStrategy(
+        name="mece",
+        description="Strict non-overlap with secondary verifier pass.",
+        variants=(
+            GenerationVariant(
+                label="structured",
+                temperature_delta=-0.20,
+                top_p=0.85,
+                prompt_addon_key="mece",
+            ),
+        ),
+        enable_mece_check=True,
+        max_mece_retries=1,
+    ),
+}
+
+
+# Keep referenced so static analysis doesn't drop them (they appear in
+# strategy variants above; this is just to silence "unused import" hints
+# if a future variant pulls model_lite / model_flash explicitly).
+_REFERENCED_MODELS = (MODEL_FLASH, MODEL_LITE, MODEL_PRO)
+
+
+def get_strategy(mode: Optional[str]) -> GenerationStrategy:
+    """Resolve `expansion_mode` → strategy. Unknown / None → default."""
+    if mode and mode in STRATEGIES:
+        return STRATEGIES[mode]
+    return STRATEGIES["default"]
+
+
+# Avoid `_REFERENCED_MODELS` flagged as unused
+_ = field, _REFERENCED_MODELS

--- a/api/schemas/expand_schema.py
+++ b/api/schemas/expand_schema.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime
 
+from schemas.context_vector import ContextVector
+
 
 class ExpandRequest(BaseModel):
     """Request model for expanding a specific node."""
@@ -92,10 +94,69 @@ class ExpandRequest(BaseModel):
         le=2_147_483_647,  # signed int32 ceiling (Gemini SDK accepts up to this)
     )
 
+    context_vector: Optional[ContextVector] = Field(
+        None,
+        description=(
+            "Business DNA from smart-classify (summary/target/edge/objective). "
+            "When present it's injected into the system_instruction so the AI "
+            "can ground children in the user's specific business context "
+            "instead of generic framework boilerplate. Optional — older "
+            "frontends don't carry it and we degrade gracefully."
+        ),
+    )
+
+    intent_mode: Optional[str] = Field(
+        None,
+        description=(
+            "User's high-level intent from smart-classify "
+            "(creation / diagnosis / choice / strategy). Tunes the prompt's "
+            "tone toward the right kind of children at deep levels. Optional."
+        ),
+        pattern="^(creation|diagnosis|choice|strategy)$",
+    )
+
+
+class ExpandChildSchema(BaseModel):
+    """
+    Strict schema for one generated child, used as Gemini's
+    `response_schema` so structured output is enforced at model level
+    rather than papered over by the JSON recovery chain.
+
+    Mirrors the loose dict fields ExpandResponse.children was using —
+    label/description are required, the others optional with defaults
+    so the model isn't forced to invent values for fields it can't
+    confidently fill.
+    """
+
+    label: str = Field(..., max_length=80)
+    description: Optional[str] = Field(None, max_length=300)
+    type: Optional[str] = Field(
+        None,
+        pattern="^(framework_branch|action_item|category_group|sub_branch|root|category)$",
+    )
+    semantic_type: Optional[str] = Field(
+        None,
+        pattern="^(finance|action|risk|persona|resource|metric|other)$",
+    )
+    importance: Optional[int] = Field(None, ge=1, le=5)
+
+
+class ExpandResponseSchema(BaseModel):
+    """Top-level shape Gemini must return when `response_schema` is set."""
+
+    children: List[ExpandChildSchema] = Field(...)
+    applied_framework_id: Optional[str] = Field(None)
+    expansion_mode: Optional[str] = Field(
+        None,
+        pattern="^(framework|logic_tree|semi_structured)$",
+    )
+    confidence_score: Optional[float] = Field(None, ge=0.0, le=1.0)
+    alternative_framework: Optional[str] = Field(None)
+
 
 class ExpandResponse(BaseModel):
     """Response from node expansion."""
-    
+
     children: List[dict] = Field(
         ...,
         description="Generated child nodes"

--- a/api/schemas/expand_schema.py
+++ b/api/schemas/expand_schema.py
@@ -115,6 +115,20 @@ class ExpandRequest(BaseModel):
         pattern="^(creation|diagnosis|choice|strategy)$",
     )
 
+    expansion_mode: Optional[str] = Field(
+        None,
+        description=(
+            "User-selected generation strategy: default | diverse | deep | "
+            "mece. Each maps to a small bundle of parameter overrides "
+            "(temperature delta, top_p, model swap, prompt addon) the "
+            "expander applies before the Gemini call. None == default. "
+            "Distinct from `ExpandResponse.expansion_mode` which describes "
+            "what kind of structure the AI produced (framework / logic_tree "
+            "/ semi_structured)."
+        ),
+        pattern="^(default|diverse|deep|mece)$",
+    )
+
 
 class ExpandChildSchema(BaseModel):
     """

--- a/api/schemas/expand_schema.py
+++ b/api/schemas/expand_schema.py
@@ -80,6 +80,18 @@ class ExpandRequest(BaseModel):
         pattern="^(Korean|English|Japanese)$"
     )
 
+    seed: Optional[int] = Field(
+        None,
+        description=(
+            "Optional Gemini sampling seed for reproducibility — passing the "
+            "same seed (with the same context) returns identical children. "
+            "Used by debug/A-B tooling and CI golden-output tests; left "
+            "empty for normal stochastic generation."
+        ),
+        ge=0,
+        le=2_147_483_647,  # signed int32 ceiling (Gemini SDK accepts up to this)
+    )
+
 
 class ExpandResponse(BaseModel):
     """Response from node expansion."""

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -106,6 +106,7 @@ export default function MapPageContent() {
         language,
         contextVector,
         intentMode,
+        expansionMode,
         setRootNode,
         setTopic,
         setIntentMode,
@@ -289,6 +290,9 @@ export default function MapPageContent() {
                 // and intent. Both optional — backend degrades cleanly.
                 ...(contextVector ? { context_vector: contextVector } : {}),
                 ...(intentMode ? { intent_mode: intentMode } : {}),
+                // Phase 2: user-selected mode (always present in store,
+                // default = "default" which the backend treats as no-op).
+                expansion_mode: expansionMode,
             }
 
             const response = await expandNode(request)
@@ -333,7 +337,13 @@ export default function MapPageContent() {
                 })
             } else {
                 const baseDesc = `${returnedChildren.length}개 하위 항목 추가됨`
-                toast.success('아이디어 확장 완료!', {
+                const titleByMode: Record<string, string> = {
+                    default: '아이디어 확장 완료!',
+                    diverse: '다양한 관점으로 확장 완료!',
+                    deep: '깊이있게 확장 완료!',
+                    mece: '핵심만 추려서 확장 완료!',
+                }
+                toast.success(titleByMode[expansionMode] ?? titleByMode.default, {
                     description: isDebug && typeof seed === 'number'
                         ? `${baseDesc} · seed=${seed}`
                         : baseDesc,
@@ -352,6 +362,7 @@ export default function MapPageContent() {
         language,
         contextVector,
         intentMode,
+        expansionMode,
         isDebug,
         searchParams,
         setExpanding,

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef } from "react"
 import { useSearchParams } from "next/navigation"
 import { MindmapCanvas } from "@/components/mindmap/mindmap-canvas"
 import { ReportPanel } from "@/components/mindmap/report-panel"
@@ -58,6 +58,34 @@ function getParentSiblingLabels(
         .map(c => c.label)
 }
 
+/**
+ * Walk every ancestor of `targetId` (excluding the target itself) and
+ * collect their `applied_framework_id`s in path order, deduplicated.
+ *
+ * Phase 0 fix: previously the frontend hardcoded `used_frameworks` to
+ * `[rootFramework]`, so the backend's MAX_FRAMEWORK_NESTING check was
+ * effectively disabled at depth ≥ 2. The store now stamps the applied
+ * framework on the target node when an expansion returns one, so each
+ * subsequent expansion can read the full chain from the tree itself.
+ */
+function collectAncestorFrameworks(
+    root: MindmapNode,
+    targetId: string,
+): string[] {
+    const out: string[] = []
+    const seen = new Set<string>()
+    let { parent } = findNodeWithParent(root, targetId)
+    while (parent) {
+        if (parent.applied_framework_id && !seen.has(parent.applied_framework_id)) {
+            out.unshift(parent.applied_framework_id)
+            seen.add(parent.applied_framework_id)
+        }
+        const next = findNodeWithParent(root, parent.id)
+        parent = next.parent
+    }
+    return out
+}
+
 export default function MapPageContent() {
     const searchParams = useSearchParams()
     const topic = searchParams.get('topic') || ''
@@ -75,6 +103,7 @@ export default function MapPageContent() {
         contextPath,
         expandingNodeId,
         isLoading,
+        language,
         setRootNode,
         setTopic,
         navigateTo,
@@ -82,6 +111,16 @@ export default function MapPageContent() {
         setLoading,
         expandNode: storeExpandNode,
     } = useMindmapStore()
+
+    // `?debug=1` exposes hidden affordances (currently the deterministic
+    // seed echo on the success toast). Read once from the URL — this is a
+    // dev/QA flag, not user-facing.
+    const isDebug = searchParams.get('debug') === '1'
+
+    // Ref-trampoline so the "다시 시도" toast action can re-invoke the
+    // current `handleExpand` without the callback referencing itself in
+    // its closure (lint rule: cannot access var before declaration).
+    const handleExpandRef = useRef<((node: MindmapNode) => Promise<void>) | null>(null)
 
     const [reportOpen, setReportOpen] = useState(false)
 
@@ -199,36 +238,55 @@ export default function MapPageContent() {
             const existingChildren = node.children?.map(c => c.label) || []
 
             // Calculate depth based on tree position
-            const { parent: nodeParent } = findNodeWithParent(rootNode, node.id)
             let depth = 0
-            let current = nodeParent
+            let current = parent
             while (current) {
                 depth++
                 const result = findNodeWithParent(rootNode, current.id)
                 current = result.parent
             }
 
+            // Collect frameworks already applied along the ancestor chain.
+            // The root framework is always present; ancestors that the AI
+            // wrapped in a sub-framework (PERSONA, SWOT, …) contribute too.
+            const ancestorFrameworks = collectAncestorFrameworks(rootNode, node.id)
+            const usedFrameworks = Array.from(
+                new Set([framework, ...ancestorFrameworks]),
+            )
+
+            // `?debug=1` URLs may include `&seed=N` to pin Gemini sampling.
+            const seedParam = searchParams.get('seed')
+            const seed = isDebug && seedParam
+                ? Number.parseInt(seedParam, 10)
+                : undefined
+
             const request: ExpandRequest = {
                 topic: rootNode.label,
                 context_path: [...contextPath, node.label],
                 target_node_label: node.label,
                 current_framework_id: framework,
-                used_frameworks: [framework],
+                used_frameworks: usedFrameworks,
                 current_depth: depth,
                 sibling_labels: siblingLabels,
                 parent_sibling_labels: parentSiblingLabels,
                 existing_children: existingChildren,
-                language: 'Korean'
+                language,
+                ...(typeof seed === 'number' && Number.isFinite(seed) ? { seed } : {}),
             }
 
             const response = await expandNode(request)
 
             // Add mode: merge existing children with new ones
+            const returnedChildren = response.children as MindmapNode[]
             const newChildren = [
                 ...(node.children || []),
-                ...response.children as MindmapNode[]
+                ...returnedChildren,
             ]
-            storeExpandNode(node.id, newChildren)
+            storeExpandNode(
+                node.id,
+                newChildren,
+                response.applied_framework_id ?? null,
+            )
 
             // Save tree to cache
             const updatedRoot = useMindmapStore.getState().rootNode
@@ -236,18 +294,58 @@ export default function MapPageContent() {
                 saveTree(topic, updatedRoot)
             }
 
-            toast.success('노드 확장 완료!', {
-                description: `${response.children.length}개 하위 항목 추가됨`
-            })
+            // Low confidence OR clearly insufficient children → warn the
+            // user with a "다시 시도" action instead of silently swallowing.
+            // We don't surface the backend's chosen target count today, so
+            // "insufficient" is anchored at < 2 children — a hard floor that
+            // any layer would consider a failure.
+            const tooFew = returnedChildren.length < 2
+            const lowConfidence =
+                typeof response.confidence_score === 'number' &&
+                response.confidence_score < 0.6
+            if (tooFew || lowConfidence) {
+                const reason = lowConfidence
+                    ? `신뢰도가 낮아요 (${Math.round((response.confidence_score ?? 0) * 100)}%)`
+                    : `${returnedChildren.length}개만 추가됐어요`
+                toast.warning('부분적으로만 확장됐어요', {
+                    description: reason,
+                    action: {
+                        label: '다시 시도',
+                        onClick: () => handleExpandRef.current?.(node),
+                    },
+                })
+            } else {
+                const baseDesc = `${returnedChildren.length}개 하위 항목 추가됨`
+                toast.success('아이디어 확장 완료!', {
+                    description: isDebug && typeof seed === 'number'
+                        ? `${baseDesc} · seed=${seed}`
+                        : baseDesc,
+                })
+            }
         } catch (error) {
             toast.error('확장 실패', {
                 description: error instanceof Error ? error.message : '알 수 없는 오류'
             })
             setExpanding(null)
         }
-    }, [rootNode, contextPath, framework, setExpanding, storeExpandNode, topic])
+    }, [
+        rootNode,
+        contextPath,
+        framework,
+        language,
+        isDebug,
+        searchParams,
+        setExpanding,
+        storeExpandNode,
+        topic,
+    ])
 
-
+    // Keep the trampoline pointing at the current handleExpand so the toast
+    // retry action always invokes the latest closure (deps may have changed
+    // since the toast was emitted).
+    useEffect(() => {
+        handleExpandRef.current = handleExpand
+    }, [handleExpand])
 
     if (isLoading || !currentNode || !rootNode) {
         return null // Suspense will show skeleton

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -104,8 +104,11 @@ export default function MapPageContent() {
         expandingNodeId,
         isLoading,
         language,
+        contextVector,
+        intentMode,
         setRootNode,
         setTopic,
+        setIntentMode,
         navigateTo,
         setExpanding,
         setLoading,
@@ -128,6 +131,16 @@ export default function MapPageContent() {
     useEffect(() => {
         setTopic(topic || null)
     }, [topic, setTopic])
+
+    // Seed intentMode from the URL when the store doesn't already have one
+    // (covers refresh / new-tab / direct URL access). The home page sets
+    // it during smart-classify; this is the recovery path.
+    useEffect(() => {
+        if (intentMode) return
+        if (intent === 'creation' || intent === 'diagnosis' || intent === 'choice' || intent === 'strategy') {
+            setIntentMode(intent)
+        }
+    }, [intent, intentMode, setIntentMode])
 
     // Initial Load: L1 노드 표시 (Backend에서 받은 l1_labels 우선 사용)
     useEffect(() => {
@@ -272,6 +285,10 @@ export default function MapPageContent() {
                 existing_children: existingChildren,
                 language,
                 ...(typeof seed === 'number' && Number.isFinite(seed) ? { seed } : {}),
+                // Phase 1: ground children in the user's actual business
+                // and intent. Both optional — backend degrades cleanly.
+                ...(contextVector ? { context_vector: contextVector } : {}),
+                ...(intentMode ? { intent_mode: intentMode } : {}),
             }
 
             const response = await expandNode(request)
@@ -333,6 +350,8 @@ export default function MapPageContent() {
         contextPath,
         framework,
         language,
+        contextVector,
+        intentMode,
         isDebug,
         searchParams,
         setExpanding,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { smartClassify } from "@/lib/api"
 import { LOADING_QUOTES, LoadingQuote } from "@/lib/framework-templates"
 import { toast } from "sonner"
 import { HeroInput, LoadingScreen, IntentMode } from "@/components/landing"
+import { useMindmapStore } from "@/stores/mindmap-store"
 import { SaveLoadButtons } from "@/components/mindmap/save-load-buttons"
 import { DottedGlowBackground } from "@/components/ui/dotted-glow-background"
 import { ConversationMessage, SmartClassifyResponse, isAPIError } from "@/types/mindmap"
@@ -18,6 +19,10 @@ type Step = "input" | "loading" | "question" | "generating"
 
 export default function HomePage() {
     const router = useRouter()
+    // Pre-seed the store with the user's smart-classify outputs so the
+    // map page has DNA + intent available for every subsequent expand call.
+    const setStoreContextVector = useMindmapStore((s) => s.setContextVector)
+    const setStoreIntentMode = useMindmapStore((s) => s.setIntentMode)
     const [step, setStep] = useState<Step>("input")
     const [topic, setTopic] = useState("")
     const [intentMode, setIntentMode] = useState<IntentMode>('creation')
@@ -75,6 +80,15 @@ export default function HomePage() {
                 intent_mode: intentMode,
                 conversation_history: conversationHistory
             })
+
+            // Stash DNA + intent in the store so /map's expand flow can use
+            // them. Done on every action path (ask_question / generate /
+            // fill_and_generate) — the user's intent is the same regardless
+            // of whether the AI needs another turn.
+            if (result.context_vector) {
+                setStoreContextVector(result.context_vector)
+            }
+            setStoreIntentMode(intentMode)
 
             if (result.action === "ask_question" && result.question) {
                 // DNA summary 저장 (AI가 누적 정보 기반으로 생성한 정제된 타이틀)

--- a/components/mindmap/mindmap-canvas.tsx
+++ b/components/mindmap/mindmap-canvas.tsx
@@ -137,6 +137,20 @@ interface CustomNodeData {
     [key: string]: unknown
 }
 
+// Phase 1: tiny semantic-type indicator (top-left of node body).
+// Backend already produces `semantic_type`; this is the first place it's
+// surfaced visually. Tailwind palette tokens chosen to match the rest
+// of the app's accent colors.
+const SEMANTIC_TYPE_COLOR: Record<string, string> = {
+    finance: 'bg-emerald-500',
+    action: 'bg-indigo-500',
+    risk: 'bg-rose-500',
+    persona: 'bg-amber-500',
+    resource: 'bg-slate-400',
+    metric: 'bg-cyan-500',
+    // 'other' intentionally not mapped → no dot rendered
+}
+
 const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data: CustomNodeData }) {
     const style = getLevelStyle(data.level)
     const isRoot = data.level === 0
@@ -144,6 +158,11 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
     // Handle 위치 결정
     const targetPos = data.side === 'left' ? Position.Right : Position.Left
     const sourcePos = data.side === 'left' ? Position.Left : Position.Right
+
+    // Semantic type color (skip root and 'other' / unset)
+    const semanticDotClass = !isRoot && data.node?.semantic_type
+        ? SEMANTIC_TYPE_COLOR[data.node.semantic_type]
+        : undefined
 
     // L1 이상 노드에서 NodeToolbar 표시 (Root 제외)
     const showToolbar = data.level >= 1
@@ -246,6 +265,15 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         position={Position.Left}
                         className="!opacity-0 !w-1 !h-1"
                     />
+
+                    {/* Semantic type indicator — small colored dot, top-left */}
+                    {semanticDotClass && (
+                        <span
+                            className={`absolute top-1.5 left-1.5 h-1.5 w-1.5 rounded-full ${semanticDotClass}`}
+                            aria-hidden="true"
+                            title={data.node?.semantic_type}
+                        />
+                    )}
 
                     {/* Node Content */}
                     <div className="flex flex-col items-center">

--- a/components/mindmap/mindmap-canvas.tsx
+++ b/components/mindmap/mindmap-canvas.tsx
@@ -19,11 +19,19 @@ import {
 import '@xyflow/react/dist/style.css'
 import { MindmapNode } from '@/types/mindmap'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { PlusSignIcon, PencilEdit01Icon, Delete02Icon, Loading03Icon, RefreshIcon, AiChat02Icon, NoteIcon } from '@hugeicons/core-free-icons'
+import { PlusSignIcon, PencilEdit01Icon, Delete02Icon, Loading03Icon, RefreshIcon, AiChat02Icon, NoteIcon, ArrowDown01Icon, InformationCircleIcon } from '@hugeicons/core-free-icons'
 import { DottedGlowBackground } from '@/components/ui/dotted-glow-background'
 import { NodeStatusIndicator } from '@/components/node-status-indicator'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+} from '@/components/ui/dropdown-menu'
 import { calculateD3Layout } from '@/lib/d3-layout'
-import { useMindmapStore } from '@/stores/mindmap-store'
+import { useMindmapStore, type ExpansionMode } from '@/stores/mindmap-store'
 import { HomeButton } from '@/components/mindmap/home-button'
 import { SaveLoadButtons } from '@/components/mindmap/save-load-buttons'
 
@@ -151,6 +159,22 @@ const SEMANTIC_TYPE_COLOR: Record<string, string> = {
     // 'other' intentionally not mapped → no dot rendered
 }
 
+// Phase 2: human labels for the expansion-mode picker. Order is the order
+// the items appear in the dropdown.
+const EXPANSION_MODE_LABEL: Record<ExpansionMode, string> = {
+    default: '기본',
+    diverse: '다양하게',
+    deep: '깊이있게',
+    mece: '핵심만 (MECE)',
+}
+
+const EXPANSION_MODE_HINT: Record<ExpansionMode, string> = {
+    default: '균형잡힌 기본 확장',
+    diverse: '서로 다른 관점으로 폭넓게',
+    deep: 'Pro 모델로 깊이 사고',
+    mece: '겹치지 않게 빠짐없이',
+}
+
 const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data: CustomNodeData }) {
     const style = getLevelStyle(data.level)
     const isRoot = data.level === 0
@@ -163,6 +187,12 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
     const semanticDotClass = !isRoot && data.node?.semantic_type
         ? SEMANTIC_TYPE_COLOR[data.node.semantic_type]
         : undefined
+
+    // Phase 2: read the user's selected expansion mode from the store and
+    // expose a small picker next to AI확장. `default` mode shows no badge so
+    // the toolbar stays uncluttered for the common case.
+    const expansionMode = useMindmapStore((s) => s.expansionMode)
+    const setExpansionMode = useMindmapStore((s) => s.setExpansionMode)
 
     // L1 이상 노드에서 NodeToolbar 표시 (Root 제외)
     const showToolbar = data.level >= 1
@@ -190,31 +220,90 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         </button>
                     )}
 
-                    {/* 2. AI확장 */}
+                    {/* 2. AI확장 + 모드 picker (split-button cluster) */}
                     {canShowExpandButton && (
-                        <button
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                // 자식이 있지만 미표시 상태면 먼저 reveal
-                                if (data.hasChildren && !data.childrenRevealed) {
-                                    data.onRevealChildren()
-                                } else {
-                                    // expand 호출 (새 자식 생성)
-                                    data.onExpand()
+                        <div className="flex items-stretch">
+                            <button
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    // 자식이 있지만 미표시 상태면 먼저 reveal
+                                    if (data.hasChildren && !data.childrenRevealed) {
+                                        data.onRevealChildren()
+                                    } else {
+                                        // expand 호출 (새 자식 생성)
+                                        data.onExpand()
+                                    }
+                                }}
+                                disabled={data.isAnyExpanding && !data.isExpanding}
+                                className={`p-1.5 rounded-l-md shadow-sm border transition-colors ${data.isAnyExpanding && !data.isExpanding
+                                    ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
+                                    : 'bg-white/90 hover:bg-indigo-100 text-slate-600 hover:text-indigo-600 border-slate-200'
+                                    }`}
+                                title={
+                                    data.isAnyExpanding && !data.isExpanding
+                                        ? "AI확장 중..."
+                                        : data.hasChildren && !data.childrenRevealed
+                                            ? "펼치기"
+                                            : `AI확장 (${EXPANSION_MODE_LABEL[expansionMode]})`
                                 }
-                            }}
-                            disabled={data.isAnyExpanding && !data.isExpanding}
-                            className={`p-1.5 rounded-md shadow-sm border transition-colors ${data.isAnyExpanding && !data.isExpanding
-                                ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
-                                : 'bg-white/90 hover:bg-indigo-100 text-slate-600 hover:text-indigo-600 border-slate-200'
-                                }`}
-                            title={data.isAnyExpanding && !data.isExpanding ? "AI확장 중..." : (data.hasChildren && !data.childrenRevealed ? "펼치기" : "AI확장")}
+                            >
+                                <HugeiconsIcon icon={AiChat02Icon} size={16} color="#ff5757" />
+                            </button>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger
+                                    onClick={(e) => e.stopPropagation()}
+                                    disabled={data.isAnyExpanding}
+                                    render={
+                                        <button
+                                            className={`px-1 rounded-r-md shadow-sm border border-l-0 transition-colors ${data.isAnyExpanding
+                                                ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
+                                                : 'bg-white/90 hover:bg-indigo-100 text-slate-500 hover:text-indigo-600 border-slate-200'
+                                                }`}
+                                            title="확장 방식 선택"
+                                        />
+                                    }
+                                >
+                                    <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                    align="start"
+                                    className="min-w-[200px]"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <DropdownMenuRadioGroup
+                                        value={expansionMode}
+                                        onValueChange={(v) => setExpansionMode(v as ExpansionMode)}
+                                    >
+                                        {(['default', 'diverse', 'deep', 'mece'] as const).map((m) => (
+                                            <DropdownMenuRadioItem key={m} value={m}>
+                                                <div className="flex flex-col">
+                                                    <span className="text-sm">{EXPANSION_MODE_LABEL[m]}</span>
+                                                    <span className="text-xs text-slate-400">{EXPANSION_MODE_HINT[m]}</span>
+                                                </div>
+                                            </DropdownMenuRadioItem>
+                                        ))}
+                                    </DropdownMenuRadioGroup>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
+                    )}
+
+                    {/* 3. 설명 보기 — AI가 description을 줬을 때만 노출.
+                        Popover 컴포넌트가 없어서 native title tooltip으로 처리;
+                        Phase 3 quality 패스에서 정식 popover로 업그레이드 예정. */}
+                    {data.node?.description && (
+                        <button
+                            type="button"
+                            onClick={(e) => e.stopPropagation()}
+                            className="p-1.5 rounded-md bg-white/90 hover:bg-sky-100 text-slate-600 hover:text-sky-600 shadow-sm border border-slate-200 transition-colors cursor-help"
+                            title={data.node.description}
+                            aria-label="이 아이디어의 설명"
                         >
-                            <HugeiconsIcon icon={AiChat02Icon} size={16} color="#ff5757" />
+                            <HugeiconsIcon icon={InformationCircleIcon} size={16} />
                         </button>
                     )}
 
-                    {/* 3. 수정 */}
+                    {/* 4. 수정 */}
                     <button
                         onClick={(e) => {
                             e.stopPropagation()

--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand'
-import { MindmapNode } from '@/types/mindmap'
+import { MindmapNode, ContextVector } from '@/types/mindmap'
 import { saveTree } from '@/lib/tree-cache'
+
+/** Intent buckets the smart-classify pipeline emits. */
+export type IntentMode = 'creation' | 'diagnosis' | 'choice' | 'strategy'
 
 type ViewMode = 'card' | 'tree' | 'mindmap'
 
@@ -43,6 +46,19 @@ interface MindmapStore {
      * refresh; default Korean. Settable via setLanguage.
      */
     language: AppLanguage
+    /**
+     * Business DNA captured by smart-classify (summary/target/edge/objective).
+     * Populated by the home page after a successful classify, then forwarded
+     * into every ExpandRequest so generated children stay specific to the
+     * user's actual business instead of generic framework boilerplate.
+     */
+    contextVector: ContextVector | null
+    /**
+     * High-level intent (creation/diagnosis/choice/strategy) chosen on the
+     * landing page. Threaded into ExpandRequest as `intent_mode` so the
+     * prompt can tone-shift toward the right kind of children.
+     */
+    intentMode: IntentMode | null
 
     // Delete/Undo State
     deletedNodeBackup: DeletedNodeBackup | null
@@ -56,6 +72,8 @@ interface MindmapStore {
     // Actions
     setTopic: (topic: string | null) => void
     setLanguage: (language: AppLanguage) => void
+    setContextVector: (cv: ContextVector | null) => void
+    setIntentMode: (mode: IntentMode | null) => void
     setRootNode: (node: MindmapNode) => void
     setCurrentNode: (node: MindmapNode) => void
     navigateTo: (node: MindmapNode) => void
@@ -92,6 +110,8 @@ const initialState = {
     contextPath: [],
     topic: null as string | null,
     language: readPersistedLanguage(),
+    contextVector: null as ContextVector | null,
+    intentMode: null as IntentMode | null,
     deletedNodeBackup: null as DeletedNodeBackup | null,
     viewMode: 'mindmap' as ViewMode,
     expandingNodeId: null,
@@ -124,6 +144,9 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
             }
         }
     },
+
+    setContextVector: (cv) => set({ contextVector: cv }),
+    setIntentMode: (mode) => set({ intentMode: mode }),
 
     setRootNode: (node) => {
         set({

--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -11,6 +11,24 @@ interface DeletedNodeBackup {
     index: number  // 부모 내 위치
 }
 
+/** Languages the AI pipeline currently supports as input/output. */
+export type AppLanguage = 'Korean' | 'English' | 'Japanese'
+
+const LANGUAGE_STORAGE_KEY = 'mindbusiness_language'
+const DEFAULT_LANGUAGE: AppLanguage = 'Korean'
+
+/** Read the persisted language pref (SSR-safe). */
+function readPersistedLanguage(): AppLanguage {
+    if (typeof window === 'undefined') return DEFAULT_LANGUAGE
+    try {
+        const v = window.localStorage.getItem(LANGUAGE_STORAGE_KEY)
+        if (v === 'Korean' || v === 'English' || v === 'Japanese') return v
+    } catch {
+        // localStorage may be unavailable (private mode etc) — fall through
+    }
+    return DEFAULT_LANGUAGE
+}
+
 interface MindmapStore {
     // Data
     rootNode: MindmapNode | null
@@ -19,6 +37,12 @@ interface MindmapStore {
     contextPath: string[]
     /** Topic key used to persist the tree to tree-cache. Set when the map page mounts. */
     topic: string | null
+    /**
+     * UI/AI language — flows into ExpandRequest.language so generated children
+     * match the user's preference. Persisted to localStorage so it survives
+     * refresh; default Korean. Settable via setLanguage.
+     */
+    language: AppLanguage
 
     // Delete/Undo State
     deletedNodeBackup: DeletedNodeBackup | null
@@ -31,6 +55,7 @@ interface MindmapStore {
 
     // Actions
     setTopic: (topic: string | null) => void
+    setLanguage: (language: AppLanguage) => void
     setRootNode: (node: MindmapNode) => void
     setCurrentNode: (node: MindmapNode) => void
     navigateTo: (node: MindmapNode) => void
@@ -41,7 +66,17 @@ interface MindmapStore {
     setExpanding: (nodeId: string | null) => void
     setEditingNodeId: (nodeId: string | null) => void  // 편집 모드 설정
     setLoading: (loading: boolean) => void
-    expandNode: (nodeId: string, children: MindmapNode[]) => void
+    /**
+     * Replace a node's children with the result of an expansion. When
+     * `appliedFrameworkId` is set, also stamp it onto the target node so
+     * subsequent expansions of any descendant can recover the full
+     * frameworks-in-path list (Phase 0 fix for the broken nesting check).
+     */
+    expandNode: (
+        nodeId: string,
+        children: MindmapNode[],
+        appliedFrameworkId?: string | null,
+    ) => void
     addChildNode: (parentId: string) => MindmapNode | null  // 수동 자식 노드 추가 (빈 라벨)
     updateNodeLabel: (nodeId: string, label: string) => void  // 노드 라벨 업데이트
     deleteNode: (nodeId: string) => boolean  // 삭제 성공 여부 반환
@@ -56,6 +91,7 @@ const initialState = {
     nodeHistory: [],
     contextPath: [],
     topic: null as string | null,
+    language: readPersistedLanguage(),
     deletedNodeBackup: null as DeletedNodeBackup | null,
     viewMode: 'mindmap' as ViewMode,
     expandingNodeId: null,
@@ -77,6 +113,17 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
     ...initialState,
 
     setTopic: (topic) => set({ topic }),
+
+    setLanguage: (language) => {
+        set({ language })
+        if (typeof window !== 'undefined') {
+            try {
+                window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
+            } catch {
+                // private mode etc — silently skip persist
+            }
+        }
+    },
 
     setRootNode: (node) => {
         set({
@@ -154,14 +201,21 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
 
     setLoading: (loading) => set({ isLoading: loading }),
 
-    expandNode: (nodeId, children) => {
+    expandNode: (nodeId, children, appliedFrameworkId) => {
         const { rootNode, currentNode, topic } = get()
         if (!rootNode || !currentNode) return
 
-        // Recursively update node with children
+        // Recursively update node with children. When the AI applied a
+        // framework, also stamp `applied_framework_id` onto the target node
+        // so future expansions of any descendant can collect the full list
+        // of frameworks-in-path (used_frameworks accumulation).
         const updateNodeChildren = (node: MindmapNode): MindmapNode => {
             if (node.id === nodeId) {
-                return { ...node, children }
+                const next: MindmapNode = { ...node, children }
+                if (appliedFrameworkId) {
+                    next.applied_framework_id = appliedFrameworkId
+                }
+                return next
             }
             return {
                 ...node,

--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -5,6 +5,23 @@ import { saveTree } from '@/lib/tree-cache'
 /** Intent buckets the smart-classify pipeline emits. */
 export type IntentMode = 'creation' | 'diagnosis' | 'choice' | 'strategy'
 
+/** User-selected expansion strategy. See ExpandRequest.expansion_mode. */
+export type ExpansionMode = 'default' | 'diverse' | 'deep' | 'mece'
+
+const EXPANSION_MODE_STORAGE_KEY = 'mindbusiness_expansion_mode'
+const DEFAULT_EXPANSION_MODE: ExpansionMode = 'default'
+
+function readPersistedExpansionMode(): ExpansionMode {
+    if (typeof window === 'undefined') return DEFAULT_EXPANSION_MODE
+    try {
+        const v = window.localStorage.getItem(EXPANSION_MODE_STORAGE_KEY)
+        if (v === 'default' || v === 'diverse' || v === 'deep' || v === 'mece') return v
+    } catch {
+        // localStorage unavailable — fall through to default
+    }
+    return DEFAULT_EXPANSION_MODE
+}
+
 type ViewMode = 'card' | 'tree' | 'mindmap'
 
 // 삭제된 노드 백업 정보
@@ -59,6 +76,13 @@ interface MindmapStore {
      * prompt can tone-shift toward the right kind of children.
      */
     intentMode: IntentMode | null
+    /**
+     * Currently-selected expansion mode (default / diverse / deep / mece).
+     * Applied to every AI확장 click until the user changes it via the
+     * mode picker. Persisted to localStorage so the choice survives a
+     * refresh.
+     */
+    expansionMode: ExpansionMode
 
     // Delete/Undo State
     deletedNodeBackup: DeletedNodeBackup | null
@@ -74,6 +98,7 @@ interface MindmapStore {
     setLanguage: (language: AppLanguage) => void
     setContextVector: (cv: ContextVector | null) => void
     setIntentMode: (mode: IntentMode | null) => void
+    setExpansionMode: (mode: ExpansionMode) => void
     setRootNode: (node: MindmapNode) => void
     setCurrentNode: (node: MindmapNode) => void
     navigateTo: (node: MindmapNode) => void
@@ -112,6 +137,7 @@ const initialState = {
     language: readPersistedLanguage(),
     contextVector: null as ContextVector | null,
     intentMode: null as IntentMode | null,
+    expansionMode: readPersistedExpansionMode(),
     deletedNodeBackup: null as DeletedNodeBackup | null,
     viewMode: 'mindmap' as ViewMode,
     expandingNodeId: null,
@@ -147,6 +173,16 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
 
     setContextVector: (cv) => set({ contextVector: cv }),
     setIntentMode: (mode) => set({ intentMode: mode }),
+    setExpansionMode: (mode) => {
+        set({ expansionMode: mode })
+        if (typeof window !== 'undefined') {
+            try {
+                window.localStorage.setItem(EXPANSION_MODE_STORAGE_KEY, mode)
+            } catch {
+                // private mode etc — silently skip persist
+            }
+        }
+    },
 
     setRootNode: (node) => {
         set({

--- a/types/mindmap.ts
+++ b/types/mindmap.ts
@@ -78,6 +78,17 @@ export interface ExpandRequest {
      * stochastic generation.
      */
     seed?: number
+    /**
+     * Business DNA from smart-classify. When present the backend injects
+     * a `[BUSINESS DNA]` block into the system_instruction so generated
+     * children are specific to the user's actual business.
+     */
+    context_vector?: ContextVector
+    /**
+     * High-level intent (creation/diagnosis/choice/strategy). Tunes the
+     * prompt's tone toward the right kind of children at deep levels.
+     */
+    intent_mode?: 'creation' | 'diagnosis' | 'choice' | 'strategy'
 }
 
 export interface ExpandResponse {

--- a/types/mindmap.ts
+++ b/types/mindmap.ts
@@ -16,6 +16,15 @@ export interface MindmapNode {
 
     // Phase 2: Monetization
     recommendations?: RecommendationNode[]
+
+    /**
+     * If the AI applied a specific framework (PERSONA, SWOT, …) when
+     * expanding this node, the framework id is stamped here. Lets later
+     * expansions of any descendant collect the full chain of frameworks
+     * along the path — used by the `used_frameworks` accumulation in
+     * map-page-content's handleExpand to fix the nesting-limit check.
+     */
+    applied_framework_id?: string
 }
 
 export interface RecommendationNode {
@@ -63,6 +72,12 @@ export interface ExpandRequest {
     existing_children?: string[]        // Already existing children (for add mode)
     force_framework?: string
     language: string
+    /**
+     * Optional Gemini sampling seed — pass an integer to make the call
+     * deterministic (debug / A-B / CI golden tests). Omit for normal
+     * stochastic generation.
+     */
+    seed?: number
 }
 
 export interface ExpandResponse {

--- a/types/mindmap.ts
+++ b/types/mindmap.ts
@@ -89,6 +89,18 @@ export interface ExpandRequest {
      * prompt's tone toward the right kind of children at deep levels.
      */
     intent_mode?: 'creation' | 'diagnosis' | 'choice' | 'strategy'
+    /**
+     * User-selected expansion strategy (Phase 2 mode dropdown). Each maps
+     * to a parameter override bundle in the backend (temperature delta,
+     * top_p, model swap, prompt addon).
+     *   - default: stage settings as-is
+     *   - diverse: hotter + top_p high + ~1.5x count + diversity prompt
+     *   - deep: Pro + HIGH reasoning + cooler + step-by-step prompt
+     *   - mece: cooler + tighter top_p + MECE-strict prompt
+     * Distinct from `ExpandResponse.expansion_mode` which describes the
+     * structure shape the AI produced.
+     */
+    expansion_mode?: 'default' | 'diverse' | 'deep' | 'mece'
 }
 
 export interface ExpandResponse {


### PR DESCRIPTION
Phases 0–3.1 of the branch-generation redesign plan (`/Users/yuhitomi/.claude/plans/resilient-juggling-gem.md`). Lays the architecture for ensemble strategies, parallel variants, candidate aggregation, and MECE detection.

## Phase 0 — silent bugs + telemetry

1. `used_frameworks` accumulates from the actual ancestor chain.
2. Language unhardcoded (`useMindmapStore.language`, persisted).
3. Optional `seed` for reproducibility.
4. `expand_telemetry` structured log line per expansion.
5. Partial-result / low-confidence retry toast.

## Phase 1 — input richness + depth tuning

6. DNA + intent_mode plumbed through (`ExpandRequest.context_vector` + `[BUSINESS DNA]`/`[INTENT]` blocks).
7. Depth-aware STAGE_CONFIG (`expand_l1`..`expand_l4`).
8. `response_schema` enforced with mime-only fallback.
9. Importance heuristic + post-pass dedupe + L3+ anti-repetition.
10. Semantic-type dot rendering in canvas.

## Phase 2 — user-selected mode + add-mode angle + rationale tooltip

11. Mode picker (default / diverse / deep / mece) — split-button with localStorage persist.
12. Add-mode `[EXPLICIT NEW ANGLE]` prompt.
13. Mode-aware success toasts + info tooltip on description.

## Phase 3.1 — strategy registry + ensemble + MECE detector

14. `api/logic/strategy_registry.py` (NEW). Four strategies (default 1-variant, diverse 3-variant ensemble, deep Pro+HIGH, mece + check). `GenerationVariant` fields are deltas on top of STAGE_CONFIG.
15. `expand_node` refactored to dispatch via the registry. Variants run in parallel via `asyncio.gather`; aggregator merges; MECE pass runs after.
16. `_run_variant` (single Gemini call factored out — temp delta, top_p, top_k, candidate_count, penalties, model override, reasoning override). Same schema-strict / mime-only fallback as Phase 1.
17. `_aggregate_candidates` — `best_of_n` (max confidence × weight) for single-variant; `fuse_dedupe` pools every child across candidates, ranks by (variant_weight × confidence), walks dropping char-bigram Jaccard overlaps ≥ 0.6.
18. `_mece_check` — Lite call returning `{"overlap": bool}`. Detect-only in 3.1; Phase 3.2 will use the result for drop + regenerate.
19. Telemetry expanded: `strategy / variants / aggregator / mece_overlap`.

**Behavior preserved**: default mode is byte-identical to Phase 2 default. mece / deep are 1-variant strategies (wire behavior unchanged + new MECE telemetry). diverse is the only materially-changed mode — 3 parallel calls (~3x cost, wall-time ≈ slowest variant).

## Out of scope (queued for Phase 3.2)

- `/api/v1/expand-v2` endpoint with rich `BranchGenerationContext`
- MECE auto-fix retry loop
- Quality rubric scorer
- Prompt caching for framework cheatsheets
- `research` / `devils_advocate` strategies
- Shadow-mode v1+v2 dual-fire telemetry

## Test plan

- [ ] Backend imports + frontend tsc/lint clean
- [ ] Default mode: identical wire behavior to Phase 2 default
- [ ] Diverse mode: Network tab shows 3 parallel /api/v1/expand sub-calls in logs (or rather: 3 parallel Gemini calls server-side; the user-facing endpoint is still single). Telemetry `variants=3 agg=fuse_dedupe`
- [ ] Deep mode: noticeably higher latency (Pro + HIGH); telemetry `strategy=deep variants=1`
- [ ] MECE mode: telemetry includes `mece_overlap=true|false` per call
- [ ] Aggregator dedup: same root + topic, expand twice with diverse mode → distinct sibling sets, no near-duplicate labels across siblings
- [ ] Importance distribution non-trivial after aggregation (re-scored by final position)
- [ ] `?debug=1&seed=42` × 2 in default mode → identical children (seed only affects single-variant; diverse with seed is currently variant-shared and may not be reproducible — known limitation, doc only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)