### PR TITLE
fix(store): reset tree state when mindmapId changes — prevent stale rootNode blocking new sessions

### DIFF
--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -189,7 +189,34 @@ function persistTree(
 export const useMindmapStore = create<MindmapStore>((set, get) => ({
     ...initialState,
 
-    setMindmapId: (mindmapId) => set({ mindmapId }),
+    setMindmapId: (mindmapId) => {
+        const currentId = get().mindmapId
+        // Switching to a different id = new session. Clear the previous
+        // session's tree-related state so /map's loader useEffect doesn't
+        // short-circuit on the stale `rootNode` guard. Without this, the
+        // loader sees a non-null rootNode left over from the previous
+        // session, returns early, and never builds the new tree from
+        // localStorage.mindmap_l1_labels — the user sees the old tree's
+        // children with the new id's URL, no tree-cache write, and the
+        // l1_labels never get cleaned up.
+        // Preferences (language, expansionMode), DNA (contextVector), and
+        // intent are kept — they're either user prefs or about to be
+        // overwritten by the home page's pre-seed for the new session.
+        if (currentId !== null && currentId !== mindmapId) {
+            set({
+                mindmapId,
+                rootNode: null,
+                currentNode: null,
+                contextPath: [],
+                nodeHistory: [],
+                expandingNodeId: null,
+                editingNodeId: null,
+                deletedNodeBackup: null,
+            })
+            return
+        }
+        set({ mindmapId })
+    },
     setTopic: (topic) => set({ topic }),
     setFrameworkId: (frameworkId) => set({ frameworkId }),
 


### PR DESCRIPTION
## Bug

After phases 0–3.1 (PR #9) landed, starting a new mindmap from the landing page renders the **previous session's children under the new URL** and silently fails to persist anything for the new id.

User-visible symptoms (production):
- Root label shows `(빈 아이디어)` instead of the typed topic
- L1 children look "generic" — they're actually the previous session's children (e.g., PERSONA labels) even when the new URL says `framework=BMC`
- `localStorage.mindmap_l1_labels` never gets cleared
- `tree-cache` for the new id is never written
- Hard reload "fixes" it superficially because Zustand state resets, but the loader still rebuilds the wrong tree

## Root cause

`/map`'s loader `useEffect` short-circuits on a stale `rootNode`:

```ts
if (rootNode) return  // 이미 로드됨
```

Zustand state is module-scoped and persists across `router.push`. The home page navigates to `/map?id=newId` without clearing tree state → loader sees the previous session's non-null `rootNode` → bails out before consuming the just-written `localStorage.mindmap_l1_labels` → no `setRootNode`, no `persistTree`, no cleanup.

## Fix

In `setMindmapId`, when the new id differs from the current one, clear tree-related state in the same `set()` call:

```ts
if (currentId !== null && currentId !== mindmapId) {
    set({
        mindmapId,
        rootNode: null,
        currentNode: null,
        contextPath: [],
        nodeHistory: [],
        expandingNodeId: null,
        editingNodeId: null,
        deletedNodeBackup: null,
    })
    return
}
```

Preferences (`language`, `expansionMode`), DNA (`contextVector`), and intent are kept — they're either user prefs or about to be overwritten by the home page's pre-seed.

The `currentId !== null` guard skips the first-ever set (null → new id) so we don't needlessly reset an already-empty tree.

## Flows fixed

- Landing page → topic → smart-classify → new id (the reported bug)
- Recent maps list → click an old map (resets old tree; loader restores from tree-cache for the clicked id)
- "자유롭게 시작" button → new id

## Test plan

- [ ] Reproduce: type topic A, generate map A. From "메인으로", type topic B, generate map B → root shows B's topic, branches are B's framework labels (not A's)
- [ ] Network tab: `mindmap_l1_labels` consumed and removed after first load of map B
- [ ] localStorage: `mindbusiness_tree_<idB>` written
- [ ] Recent maps: click old map → its cached tree restored, not stale state from current session
- [ ] Hard reload still works: tree-cache restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)