### PR TITLE
feat(canvas): 노드 디자인 개편 + 수동 추가 UX 정비 + reveal 상태 복원 fix

### DIFF
--- a/api/logic/expander.py
+++ b/api/logic/expander.py
@@ -33,14 +33,39 @@ from logic.strategy_registry import (
 logger = logging.getLogger(__name__)
 
 
-# Hard depth limit (L4 is maximum)
-MAX_DEPTH = 4
+# Hard depth limit for AI expansion (L7 is maximum). Past L7 → manual add only.
+MAX_DEPTH = 7
 
 # Framework nesting limit
 MAX_FRAMEWORK_NESTING = 2
 
 # Maximum retry for insufficient children
 MAX_RETRY = 1
+
+
+def _auto_pick_mode(target_layer: int) -> str:
+    """
+    Default mode selection by depth when the caller doesn't specify one.
+
+    L1 (categorization) → `mece`: top-level slots should be non-overlapping
+        and collectively exhaustive — a MECE-strict prompt + secondary
+        validator catches the predictable failure mode of this layer.
+    L2-L3 (analysis)    → `default`: balanced single Flash call. Most
+        expansions land here and the workhorse strategy is plenty.
+    L4 (action)         → `diverse`: action-oriented children benefit
+        from multiple angles (financial / operational / cultural / …),
+        so the 3-variant ensemble is worth the ~3x cost at the leaf
+        level where breadth matters more than speed.
+
+    The mapping is intentionally conservative — only L1 and L4 deviate
+    from `default`. We can tune this once telemetry shows which depths
+    actually benefit from which strategy.
+    """
+    if target_layer <= 1:
+        return "mece"
+    if target_layer >= 4:
+        return "diverse"
+    return "default"
 
 
 # Phase 2: user-selected expansion modes. Each maps to a small bundle of
@@ -154,11 +179,19 @@ class NodeExpander:
                 stage_key = "expand"
 
             # 5. Phase 3: resolve strategy + fan variants out in parallel.
-            #     `default` strategy = 1 variant (current behavior).
-            #     `diverse` = 3 variants → fuse_dedupe aggregator.
-            #     `deep` = Pro + HIGH reasoning, single variant.
-            #     `mece` = single variant + MECE validator pass.
-            mode = request.expansion_mode or "default"
+            #     If the caller didn't pick a mode, auto-select by depth:
+            #       L1 (categorize)  → mece    (clean non-overlapping slots)
+            #       L2-L3 (analyze)  → default (balanced 1-call)
+            #       L4 (action)      → diverse (3-variant ensemble for variety)
+            #     The user-facing mode picker was removed because the labels
+            #     weren't intuitive; the backend picks the right strategy
+            #     based on where in the tree the expansion is happening.
+            #     Callers can still override by passing `expansion_mode`
+            #     (debug / future power-user flow).
+            if request.expansion_mode:
+                mode = request.expansion_mode
+            else:
+                mode = _auto_pick_mode(target_layer)
             strategy = get_strategy(mode)
             base_temp = STAGE_CONFIG[stage_key]["temperature"]
             max_children = self._get_layer_definition(request.current_depth).get("max_children", 5)

--- a/app/map/map-page-content.tsx
+++ b/app/map/map-page-content.tsx
@@ -111,7 +111,6 @@ export default function MapPageContent() {
         language,
         contextVector,
         intentMode,
-        expansionMode,
         setRootNode,
         setTopic,
         setMindmapId,
@@ -339,9 +338,10 @@ export default function MapPageContent() {
                 // and intent. Both optional — backend degrades cleanly.
                 ...(contextVector ? { context_vector: contextVector } : {}),
                 ...(intentMode ? { intent_mode: intentMode } : {}),
-                // Phase 2: user-selected mode (always present in store,
-                // default = "default" which the backend treats as no-op).
-                expansion_mode: expansionMode,
+                // Mode is auto-picked by the backend based on depth (L1
+                // → mece, L2-L3 → default, L4 → diverse). We don't send
+                // expansion_mode so the strategy registry's depth-based
+                // auto-select kicks in.
             }
 
             const response = await expandNode(request)
@@ -390,13 +390,7 @@ export default function MapPageContent() {
                 })
             } else {
                 const baseDesc = `${returnedChildren.length}개 하위 항목 추가됨`
-                const titleByMode: Record<string, string> = {
-                    default: '아이디어 확장 완료!',
-                    diverse: '다양한 관점으로 확장 완료!',
-                    deep: '깊이있게 확장 완료!',
-                    mece: '핵심만 추려서 확장 완료!',
-                }
-                toast.success(titleByMode[expansionMode] ?? titleByMode.default, {
+                toast.success('아이디어 확장 완료!', {
                     description: isDebug && typeof seed === 'number'
                         ? `${baseDesc} · seed=${seed}`
                         : baseDesc,
@@ -415,7 +409,6 @@ export default function MapPageContent() {
         language,
         contextVector,
         intentMode,
-        expansionMode,
         isDebug,
         searchParams,
         setExpanding,

--- a/components/mindmap/mindmap-canvas.tsx
+++ b/components/mindmap/mindmap-canvas.tsx
@@ -15,24 +15,15 @@ import {
     Position,
     useReactFlow,
     ReactFlowProvider,
-    NodeToolbar,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { MindmapNode } from '@/types/mindmap'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { PlusSignIcon, PencilEdit01Icon, Delete02Icon, Loading03Icon, RefreshIcon, AiChat02Icon, NoteIcon, ArrowDown01Icon, InformationCircleIcon } from '@hugeicons/core-free-icons'
+import { PlusSignIcon, Edit02Icon, Delete02Icon, Loading03Icon, RefreshIcon, AiChat02Icon, NoteIcon } from '@hugeicons/core-free-icons'
 import { DottedGlowBackground } from '@/components/ui/dotted-glow-background'
 import { NodeStatusIndicator } from '@/components/node-status-indicator'
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-} from '@/components/ui/dropdown-menu'
 import { calculateD3Layout } from '@/lib/d3-layout'
-import { useMindmapStore, type ExpansionMode } from '@/stores/mindmap-store'
+import { useMindmapStore } from '@/stores/mindmap-store'
 import { HomeButton } from '@/components/mindmap/home-button'
 import { SaveLoadButtons } from '@/components/mindmap/save-load-buttons'
 import { Button } from '@/components/ui/button'
@@ -56,81 +47,101 @@ interface MindmapCanvasProps {
     onReportOpen?: () => void
 }
 
-// Maximum children per level (for hiding expand button)
+// Maximum children per level (for hiding expand/add button)
 const MAX_CHILDREN_PER_LEVEL: Record<number, number> = {
     1: 5,  // L1 → L2: max 5
     2: 4,  // L2 → L3: max 4
     3: 3,  // L3 → L4: max 3
+    // L4+ falls back to default below (3)
 }
+const MAX_CHILDREN_DEFAULT = 3
+// AI 자동 확장은 L7까지. L8+ 부터는 수동 추가만 가능.
+const MAX_AI_DEPTH = 7
+// 수동 추가 안전망 — 그래프 폭주 방지를 위한 soft cap
+const MAX_MANUAL_DEPTH = 30
 
 // ─── Level별 Monochrome 스타일 ───
-// L0: Root - 진한 배경
-// L1: 배경/테두리 없음, 굵은 Underline
-// L2: 배경 있음, 테두리 없음
-// L3: 배경 없음, 얇은 테두리
-// L4: 배경/테두리 없음
+// L0(Root): 진한 fill (slate-800).
+// L1-L4: fill, 점진적으로 옅게 (slate-700 → slate-200).
+// L5-L7: border-only, 굵기 점진적으로 얇게 (3px → 1.5px).
+// L8+: border-only, 1px로 통일.
 interface LevelStyle {
     bg: string
     text: string
     border: string
     hasBg: boolean
     hasBorder: boolean
-    hasUnderline: boolean
-    underlineWeight: 'bold' | 'thin' | 'none'
+    borderWidth: number  // px
 }
 
 function getLevelStyle(level: number): LevelStyle {
-    switch (level) {
-        case 0: // Root
-            return {
-                bg: '#1e293b',
-                text: '#ffffff',
-                border: '#334155',
-                hasBg: true,
-                hasBorder: false,
-                hasUnderline: false,
-                underlineWeight: 'none'
-            }
-        case 1: // L1: 배경/테두리 없음, 굵은 Underline
-            return {
-                bg: 'transparent',
-                text: '#1e293b',
-                border: 'transparent',
-                hasBg: false,
-                hasBorder: false,
-                hasUnderline: true,
-                underlineWeight: 'bold'
-            }
-        case 2: // L2: 배경 있음, 테두리 없음
-            return {
-                bg: '#e2e8f0',  // 더 질은 배경 (slate-200)
-                text: '#334155',
-                border: 'transparent',
-                hasBg: true,
-                hasBorder: false,
-                hasUnderline: false,
-                underlineWeight: 'none'
-            }
-        case 3: // L3: 배경 없음, 얇은 테두리
-            return {
-                bg: 'transparent',
-                text: '#475569',
-                border: '#64748b',  // 더 질은 테두리 (slate-500, 텍스트보다 약간 옆게)
-                hasBg: false,
-                hasBorder: true,
-                hasUnderline: false,
-                underlineWeight: 'none'
-            }
-        default: // L4+: 배경/테두리 없음
-            return {
-                bg: 'transparent',
-                text: '#64748b',
-                border: 'transparent',
-                hasBg: false,
-                hasBorder: false,
-                hasUnderline: false,
-                underlineWeight: 'none'
-            }
+    // ─── Fill 영역: L0 ~ L4 ───
+    if (level === 0) {
+        return {
+            bg: '#1e293b',  // slate-800 (root)
+            text: '#ffffff',
+            border: 'transparent',
+            hasBg: true,
+            hasBorder: false,
+            borderWidth: 0,
+        }
+    }
+    if (level === 1) {
+        return {
+            bg: '#475569',  // slate-600
+            text: '#ffffff',
+            border: 'transparent',
+            hasBg: true,
+            hasBorder: false,
+            borderWidth: 0,
+        }
+    }
+    if (level === 2) {
+        return {
+            bg: '#94a3b8',  // slate-400
+            text: '#ffffff',
+            border: 'transparent',
+            hasBg: true,
+            hasBorder: false,
+            borderWidth: 0,
+        }
+    }
+    if (level === 3) {
+        return {
+            bg: '#cbd5e1',  // slate-300
+            text: '#1e293b',
+            border: 'transparent',
+            hasBg: true,
+            hasBorder: false,
+            borderWidth: 0,
+        }
+    }
+    if (level === 4) {
+        return {
+            bg: '#e2e8f0',  // slate-200
+            text: '#334155',
+            border: 'transparent',
+            hasBg: true,
+            hasBorder: false,
+            borderWidth: 0,
+        }
+    }
+
+    // ─── Border 영역: L5+ ───
+    // 굵기: L5=3px → L6=2px → L7=1.5px → L8+=1px
+    let borderWidth: number
+    if (level === 5) borderWidth = 3
+    else if (level === 6) borderWidth = 2
+    else if (level === 7) borderWidth = 1.5
+    else borderWidth = 1  // L8+
+
+    return {
+        bg: 'transparent',
+        text: '#475569',  // slate-600
+        border: '#64748b',  // slate-500
+        hasBg: false,
+        hasBorder: true,
+        borderWidth,
     }
 }
 
@@ -158,36 +169,6 @@ interface CustomNodeData {
     [key: string]: unknown
 }
 
-// Phase 1: tiny semantic-type indicator (top-left of node body).
-// Backend already produces `semantic_type`; this is the first place it's
-// surfaced visually. Tailwind palette tokens chosen to match the rest
-// of the app's accent colors.
-const SEMANTIC_TYPE_COLOR: Record<string, string> = {
-    finance: 'bg-emerald-500',
-    action: 'bg-indigo-500',
-    risk: 'bg-rose-500',
-    persona: 'bg-amber-500',
-    resource: 'bg-slate-400',
-    metric: 'bg-cyan-500',
-    // 'other' intentionally not mapped → no dot rendered
-}
-
-// Phase 2: human labels for the expansion-mode picker. Order is the order
-// the items appear in the dropdown.
-const EXPANSION_MODE_LABEL: Record<ExpansionMode, string> = {
-    default: '기본',
-    diverse: '다양하게',
-    deep: '깊이있게',
-    mece: '핵심만 (MECE)',
-}
-
-const EXPANSION_MODE_HINT: Record<ExpansionMode, string> = {
-    default: '균형잡힌 기본 확장',
-    diverse: '서로 다른 관점으로 폭넓게',
-    deep: 'Pro 모델로 깊이 사고',
-    mece: '겹치지 않게 빠짐없이',
-}
-
 const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data: CustomNodeData }) {
     const style = getLevelStyle(data.level)
     const isRoot = data.level === 0
@@ -196,16 +177,6 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
     const targetPos = data.side === 'left' ? Position.Right : Position.Left
     const sourcePos = data.side === 'left' ? Position.Left : Position.Right
 
-    // Semantic type color (skip root and 'other' / unset)
-    const semanticDotClass = !isRoot && data.node?.semantic_type
-        ? SEMANTIC_TYPE_COLOR[data.node.semantic_type]
-        : undefined
-
-    // Phase 2: read the user's selected expansion mode from the store and
-    // expose a small picker next to AI확장. `default` mode shows no badge so
-    // the toolbar stays uncluttered for the common case.
-    const expansionMode = useMindmapStore((s) => s.expansionMode)
-    const setExpansionMode = useMindmapStore((s) => s.setExpansionMode)
 
     // Toolbar visible on every node, including the root (the root is the
     // user's mindmap title and should be editable). Delete is hidden on
@@ -214,138 +185,110 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
     const showToolbar = true
     const canDelete = !isRoot
 
-    // 확장 버튼 표시 조건: level < 4 AND children < max
-    const maxChildren = MAX_CHILDREN_PER_LEVEL[data.level] || 5
-    const canShowExpandButton = data.level < 4 && data.childrenCount < maxChildren
+    // AI 확장 버튼: level < 7 AND children < max
+    // 수동 추가(+) 버튼: 레벨 제한 없음 (단, soft cap MAX_MANUAL_DEPTH 까지)
+    const maxChildren = MAX_CHILDREN_PER_LEVEL[data.level] || MAX_CHILDREN_DEFAULT
+    const canShowAIButton = data.level < MAX_AI_DEPTH && data.childrenCount < maxChildren
+    const canShowAddButton = data.level < MAX_MANUAL_DEPTH && data.childrenCount < maxChildren
+
+    // 편집 모드 진입 시 contenteditable 포커스 + 라벨 초기화. ref callback에
+    // 두면 매 렌더마다 실행되어 사용자 키 입력을 덮어쓰는 문제가 있어서
+    // useEffect로 isEditing 진입 시 1회만 실행.
+    const editableRef = useRef<HTMLDivElement>(null)
+    useEffect(() => {
+        if (!data.isEditing) return
+        const el = editableRef.current
+        if (!el) return
+        if (el.textContent !== data.label) {
+            el.textContent = data.label
+        }
+        // 50ms defer: React Flow가 새 노드의 transform/position 계산 + nodes
+        // 동기화 완료 후 포커스. rAF 한 번으로는 충분하지 않은 경우가 있어
+        // setTimeout으로 좀 더 안정적으로 늦춤.
+        const timeoutId = setTimeout(() => {
+            el.focus({ preventScroll: true })
+            const sel = window.getSelection()
+            if (!sel) return
+            const range = document.createRange()
+            if (data.label) {
+                // 라벨 있음 → 전체 선택 (Edit 흐름에서 즉시 덮어쓰기 가능)
+                range.selectNodeContents(el)
+            } else {
+                // 빈 contenteditable은 텍스트 노드가 없어 일부 브라우저에서
+                // 커서 배치가 모호함 → 명시적으로 element 시작 지점에 collapse
+                range.setStart(el, 0)
+                range.collapse(true)
+            }
+            sel.removeAllRanges()
+            sel.addRange(range)
+        }, 50)
+        return () => clearTimeout(timeoutId)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data.isEditing])
 
     return (
-        <div>
-            {/* NodeToolbar for L1+ nodes - 선택 시 상단에 표시 */}
+        <div className="group relative">
+            {/* Custom hover toolbar — React Flow의 NodeToolbar는 portal로
+                렌더되어 group-hover가 안 닿아서, 직접 absolute로 노드 위에
+                배치. 카드 hover 시 opacity로 페이드인. */}
             {showToolbar && (
-                <NodeToolbar position={Position.Top} className="flex gap-1">
-                    {/* 1. 추가 (수동) */}
-                    {canShowExpandButton && (
+                <div
+                    className="absolute left-1/2 -translate-x-1/2 -top-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-20"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    {/* 1. AI확장 */}
+                    {canShowAIButton && (
                         <button
                             onClick={(e) => {
                                 e.stopPropagation()
-                                data.onAddChild?.()
-                            }}
-                            className="p-1.5 rounded-md bg-white/90 hover:bg-green-100 text-slate-600 hover:text-green-600 shadow-sm border border-slate-200 transition-colors"
-                            title="추가"
-                        >
-                            <HugeiconsIcon icon={PlusSignIcon} size={16} />
-                        </button>
-                    )}
-
-                    {/* 2. AI확장 + 모드 picker (split-button cluster) */}
-                    {canShowExpandButton && (
-                        <div className="flex items-stretch">
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    // 자식이 있지만 미표시 상태면 먼저 reveal
-                                    if (data.hasChildren && !data.childrenRevealed) {
-                                        data.onRevealChildren()
-                                    } else {
-                                        // expand 호출 (새 자식 생성)
-                                        data.onExpand()
-                                    }
-                                }}
-                                disabled={data.isAnyExpanding && !data.isExpanding}
-                                className={`p-1.5 rounded-l-md shadow-sm border transition-colors ${data.isAnyExpanding && !data.isExpanding
-                                    ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
-                                    : 'bg-white/90 hover:bg-indigo-100 text-slate-600 hover:text-indigo-600 border-slate-200'
-                                    }`}
-                                title={
-                                    data.isAnyExpanding && !data.isExpanding
-                                        ? "AI확장 중..."
-                                        : data.hasChildren && !data.childrenRevealed
-                                            ? "펼치기"
-                                            : `AI확장 (${EXPANSION_MODE_LABEL[expansionMode]})`
+                                if (data.hasChildren && !data.childrenRevealed) {
+                                    data.onRevealChildren()
+                                } else {
+                                    data.onExpand()
                                 }
-                            >
-                                <HugeiconsIcon icon={AiChat02Icon} size={16} color="#ff5757" />
-                            </button>
-                            <DropdownMenu>
-                                <DropdownMenuTrigger
-                                    onClick={(e) => e.stopPropagation()}
-                                    disabled={data.isAnyExpanding}
-                                    render={
-                                        <button
-                                            className={`px-1 rounded-r-md shadow-sm border border-l-0 transition-colors ${data.isAnyExpanding
-                                                ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
-                                                : 'bg-white/90 hover:bg-indigo-100 text-slate-500 hover:text-indigo-600 border-slate-200'
-                                                }`}
-                                            title="확장 방식 선택"
-                                        />
-                                    }
-                                >
-                                    <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent
-                                    align="start"
-                                    className="min-w-[200px]"
-                                    onClick={(e) => e.stopPropagation()}
-                                >
-                                    <DropdownMenuRadioGroup
-                                        value={expansionMode}
-                                        onValueChange={(v) => setExpansionMode(v as ExpansionMode)}
-                                    >
-                                        {(['default', 'diverse', 'deep', 'mece'] as const).map((m) => (
-                                            <DropdownMenuRadioItem key={m} value={m}>
-                                                <div className="flex flex-col">
-                                                    <span className="text-sm">{EXPANSION_MODE_LABEL[m]}</span>
-                                                    <span className="text-xs text-slate-400">{EXPANSION_MODE_HINT[m]}</span>
-                                                </div>
-                                            </DropdownMenuRadioItem>
-                                        ))}
-                                    </DropdownMenuRadioGroup>
-                                </DropdownMenuContent>
-                            </DropdownMenu>
-                        </div>
-                    )}
-
-                    {/* 3. 설명 보기 — AI가 description을 줬을 때만 노출.
-                        Popover 컴포넌트가 없어서 native title tooltip으로 처리;
-                        Phase 3 quality 패스에서 정식 popover로 업그레이드 예정. */}
-                    {data.node?.description && (
-                        <button
-                            type="button"
-                            onClick={(e) => e.stopPropagation()}
-                            className="p-1.5 rounded-md bg-white/90 hover:bg-sky-100 text-slate-600 hover:text-sky-600 shadow-sm border border-slate-200 transition-colors cursor-help"
-                            title={data.node.description}
-                            aria-label="이 아이디어의 설명"
+                            }}
+                            disabled={data.isAnyExpanding && !data.isExpanding}
+                            className={`h-8 w-8 flex items-center justify-center rounded-md shadow-sm border transition-colors ${data.isAnyExpanding && !data.isExpanding
+                                ? 'bg-slate-100 text-slate-300 border-slate-200 cursor-not-allowed'
+                                : 'bg-white/90 hover:bg-indigo-100 text-slate-600 hover:text-indigo-600 border-slate-200'
+                                }`}
+                            title={data.isAnyExpanding && !data.isExpanding
+                                ? "AI확장 중..."
+                                : data.hasChildren && !data.childrenRevealed
+                                    ? "펼치기"
+                                    : "AI확장"
+                            }
                         >
-                            <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+                            <HugeiconsIcon icon={AiChat02Icon} size={20} color="#ff5757" />
                         </button>
                     )}
 
-                    {/* 4. 수정 */}
+                    {/* 2. 수정 */}
                     <button
                         onClick={(e) => {
                             e.stopPropagation()
                             data.onEdit?.()
                         }}
-                        className="p-1.5 rounded-md bg-white/90 hover:bg-amber-100 text-slate-600 hover:text-amber-600 shadow-sm border border-slate-200 transition-colors"
+                        className="h-8 w-8 flex items-center justify-center rounded-md bg-white/90 hover:bg-amber-100 text-slate-600 hover:text-amber-600 shadow-sm border border-slate-200 transition-colors"
                         title="수정"
                     >
-                        <HugeiconsIcon icon={PencilEdit01Icon} size={16} />
+                        <HugeiconsIcon icon={Edit02Icon} size={16} />
                     </button>
 
-                    {/* 4. 삭제 (root는 숨김) */}
+                    {/* 3. 삭제 (root는 숨김) */}
                     {canDelete && (
                         <button
                             onClick={(e) => {
                                 e.stopPropagation()
                                 data.onDelete?.()
                             }}
-                            className="p-1.5 rounded-md bg-white/90 hover:bg-red-100 text-slate-600 hover:text-red-600 shadow-sm border border-slate-200 transition-colors"
+                            className="h-8 w-8 flex items-center justify-center rounded-md bg-white/90 hover:bg-red-100 text-slate-600 hover:text-red-600 shadow-sm border border-slate-200 transition-colors"
                             title="삭제"
                         >
                             <HugeiconsIcon icon={Delete02Icon} size={16} />
                         </button>
                     )}
-                </NodeToolbar>
+                </div>
             )}
             <NodeStatusIndicator
                 status={data.isExpanding ? "loading" : "initial"}
@@ -357,13 +300,18 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         hover:scale-105 cursor-pointer text-center
                         ${isRoot ? 'min-w-[200px] max-w-[320px] rounded-[9px] shadow-lg hover:shadow-xl' : 'min-w-[120px] max-w-[400px]'}
                         ${style.hasBg && !isRoot ? 'rounded-[9px]' : ''}
-                        ${style.hasBorder ? 'rounded-[9px] border' : ''}
+                        ${style.hasBorder ? 'rounded-[9px]' : ''}
                     `}
                     style={{
                         background: style.bg,
                         color: style.text,
-                        borderColor: style.hasBorder ? style.border : 'transparent',
-                        borderWidth: style.hasBorder ? '1px' : '0',
+                        // border 대신 inset box-shadow로 가짜 테두리.
+                        // CSS border는 외곽 너비를 늘려 fill 노드보다 커 보이는
+                        // 문제가 있어서, inset shadow로 안쪽에 선 그려 외곽 사이즈
+                        // 일치시킴. (root는 기존 외곽 그림자 유지를 위해 보존)
+                        boxShadow: style.hasBorder
+                            ? `inset 0 0 0 ${style.borderWidth}px ${style.border}`
+                            : undefined,
                     }}
                 >
                     {/* Hidden Handles for edge connections */}
@@ -374,63 +322,61 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         className="!opacity-0 !w-1 !h-1"
                     />
 
-                    {/* Semantic type indicator — small colored dot, top-left */}
-                    {semanticDotClass && (
-                        <span
-                            className={`absolute top-1.5 left-1.5 h-1.5 w-1.5 rounded-full ${semanticDotClass}`}
-                            aria-hidden="true"
-                            title={data.node?.semantic_type}
-                        />
-                    )}
-
                     {/* Node Content */}
                     <div className="flex flex-col items-center">
                         {data.isEditing ? (
                             // 인라인 편집 모드 — autoFocus 대신 ref + 데스크톱에서만 focus (iOS 줌 방지)
-                            <input
-                                type="text"
-                                ref={(el) => {
-                                    if (!el) return
-                                    // Avoid mobile auto-zoom: only focus on hover-capable (desktop) devices
-                                    if (typeof window !== 'undefined' && window.matchMedia?.('(hover: hover)').matches) {
-                                        el.focus()
-                                        el.select()
-                                    }
-                                }}
-                                placeholder="아이디어 입력..."
-                                className="nodrag px-2 py-1 text-base font-semibold bg-white border border-indigo-400 rounded outline-none focus:ring-2 focus:ring-indigo-500 text-slate-800 min-w-[100px]"
+                            <div
+                                role="textbox"
+                                contentEditable
+                                suppressContentEditableWarning
+                                data-placeholder="아이디어 입력..."
+                                ref={editableRef}
+                                className="nodrag inline-block min-w-[100px] max-w-[280px] max-h-[96px] overflow-y-auto px-2 py-1 text-base font-semibold bg-white border border-indigo-400 rounded outline-none focus:ring-2 focus:ring-indigo-500 text-slate-800 leading-snug whitespace-pre-wrap break-words text-left empty:before:content-[attr(data-placeholder)] empty:before:text-slate-400 empty:before:pointer-events-none"
                                 onKeyDown={(e) => {
-                                    if (e.key === 'Enter') {
-                                        const value = (e.target as HTMLInputElement).value.trim()
+                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                        e.preventDefault()
+                                        const value = (e.currentTarget.textContent || '').trim()
                                         if (value) {
                                             data.onUpdateLabel?.(value)
+                                        } else if (!data.label) {
+                                            data.onUpdateLabel?.('새 아이디어')
                                         } else {
                                             data.onCancelEdit?.()
                                         }
                                     } else if (e.key === 'Escape') {
+                                        e.preventDefault()
                                         data.onCancelEdit?.()
                                     }
                                 }}
                                 onBlur={(e) => {
-                                    const value = e.target.value.trim()
-                                    if (value) {
+                                    const value = (e.currentTarget.textContent || '').trim()
+                                    if (value && value !== data.label) {
                                         data.onUpdateLabel?.(value)
+                                    } else if (!value && !data.label) {
+                                        data.onUpdateLabel?.('새 아이디어')
                                     } else {
                                         data.onCancelEdit?.()
                                     }
                                 }}
                             />
                         ) : (
-                            // 일반 라벨 표시
-                            <span
-                                className={`
-                                    font-semibold 
-                                    ${isRoot ? 'text-base line-clamp-3' : 'text-sm line-clamp-2'}
-                                    ${style.hasUnderline && style.underlineWeight === 'bold' ? 'border-b-2 border-slate-800' : ''}
-                                `}
-                            >
-                                {data.label || '(빈 아이디어)'}
-                            </span>
+                            // 일반 라벨 표시 + (있을 때) AI 설명을 작은 글씨로
+                            <>
+                                <span
+                                    className={`
+                                        inline-block max-w-[280px] text-center font-semibold leading-snug whitespace-pre-wrap break-words
+                                        ${isRoot ? 'text-base' : 'text-sm'}
+                                    `}
+                                >
+                                    {data.label || '새 아이디어'}
+                                </span>
+                                {!isRoot && data.node?.description && (
+                                    <span className="mt-1 max-w-[180px] text-[11px] leading-snug text-slate-400 break-keep whitespace-normal">
+                                        {data.node.description}
+                                    </span>
+                                )}
+                            </>
                         )}
                     </div>
 
@@ -441,6 +387,25 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: { data
                         position={Position.Right}
                         className="!opacity-0 !w-1 !h-1"
                     />
+
+                    {/* 추가 (수동 자식) — 노드 가장자리(자식이 자라나는 방향)에
+                        absolute로 배치. side='right' 노드면 우측, 'left'면 좌측,
+                        root('center')는 우측을 기본으로 함. 시각적으로 "여기에
+                        새 가지가 자란다"는 직관을 줌. */}
+                    {canShowAddButton && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                data.onAddChild?.()
+                            }}
+                            className={`absolute top-1/2 -translate-y-1/2 ${data.side === 'left' ? '-left-4' : '-right-4'
+                                } h-8 w-8 rounded-full bg-white hover:bg-green-100 text-slate-500 hover:text-green-600 shadow-sm border border-slate-200 flex items-center justify-center z-10 opacity-0 group-hover:opacity-100 transition-opacity`}
+                            title="자식 추가"
+                            aria-label="자식 추가"
+                        >
+                            <HugeiconsIcon icon={PlusSignIcon} size={16} />
+                        </button>
+                    )}
                 </div>
             </NodeStatusIndicator>
         </div>
@@ -512,6 +477,34 @@ function MindmapCanvasInner({
     // L1 노드 ID들 중 자식이 revealed된 것들 (declared first so callbacks below can capture)
     const [revealedParentIds, setRevealedParentIds] = useState<Set<string>>(new Set())
 
+    // 새로고침 / 페이지 재진입 시 트리는 localStorage에서 복원되지만 이 reveal
+    // 상태는 React 로컬 state라 초기화됨. 그러면 L2+ 자식은 store에 있어도
+    // visibleNodes 필터에서 가려지고, 사용자가 + 클릭으로 reveal 이벤트를
+    // 발생시키는 순간 줄줄이 나타나서 "1클릭 = N개 생성"으로 보였음.
+    // → 첫 트리 로드 시 자식 있는 모든 노드를 자동으로 reveal 처리.
+    const revealInitializedRef = useRef(false)
+    useEffect(() => {
+        if (revealInitializedRef.current) return
+        if (!rootNode) return
+        const ids = new Set<string>()
+        const walk = (n: MindmapNode) => {
+            if (n.children && n.children.length > 0) {
+                ids.add(n.id)
+                n.children.forEach(walk)
+            }
+        }
+        walk(rootNode)
+        if (ids.size > 0) {
+            setRevealedParentIds(prev => {
+                // 사용자가 이 effect 직전에 토글한 상태가 있을 수 있어 union으로 머지
+                const next = new Set(prev)
+                ids.forEach(id => next.add(id))
+                return next
+            })
+        }
+        revealInitializedRef.current = true
+    }, [rootNode])
+
     // 수동 자식 노드 추가 핸들러
     const handleAddChild = useCallback((parentId: string) => {
         const newNode = addChildNode(parentId)
@@ -577,19 +570,13 @@ function MindmapCanvasInner({
                     onEdit: () => setEditingNodeId(nodeId),
                     isEditing: editingNodeId === nodeId,
                     onUpdateLabel: (label: string) => updateNodeLabel(nodeId, label),
-                    onCancelEdit: () => {
-                        // 빈 노드면 삭제, 아니면 편집 취소만
-                        if (!nodeData.label) {
-                            deleteNode(nodeId)
-                        }
-                        setEditingNodeId(null)
-                    },
+                    onCancelEdit: () => setEditingNodeId(null),
                 }
             }
         })
 
         return { nodes: enhancedNodes, edges: result.edges }
-    }, [rootNode, onNodeExpand, expanding, revealedParentIds, handleRevealChildren, handleAddChild, handleDeleteNode, editingNodeId, updateNodeLabel, deleteNode, setEditingNodeId])
+    }, [rootNode, onNodeExpand, expanding, revealedParentIds, handleRevealChildren, handleAddChild, handleDeleteNode, editingNodeId, updateNodeLabel, setEditingNodeId])
 
     // ─── 표시할 노드/엣지 필터링 ───
     // Root(L0) + L1은 항상 표시, L2+는 부모가 revealed일 때만 표시
@@ -663,14 +650,6 @@ function MindmapCanvasInner({
         onNodeSelect?.(mindmapNode)
     }, [onNodeSelect, expanding])
 
-    // 더블 클릭 / 더블 탭 → 인라인 편집 모드. React Flow가 mouse + touch
-    // double-tap 둘 다 onNodeDoubleClick으로 발화시키므로 모바일도 자동 커버됨.
-    const handleNodeDoubleClick = useCallback((event: React.MouseEvent, node: Node) => {
-        if (expanding) return
-        const mindmapNode = node.data.node as MindmapNode
-        setEditingNodeId(mindmapNode.id)
-    }, [expanding, setEditingNodeId])
-
     return (
         <div className="relative w-full h-full min-h-screen bg-slate-50">
             {/* Aceternity Dotted Glow Background */}
@@ -692,9 +671,9 @@ function MindmapCanvasInner({
                     onNodesChange={onNodesChange}
                     onEdgesChange={onEdgesChange}
                     onNodeClick={handleNodeClick}
-                    onNodeDoubleClick={handleNodeDoubleClick}
                     nodeTypes={nodeTypes}
                     nodesDraggable={!expanding}
+                    nodesFocusable={false}
                     fitViewOptions={{ padding: 0.3 }}
                     attributionPosition="bottom-left"
                     minZoom={0.2}

--- a/components/mindmap/mindmap-canvas.tsx
+++ b/components/mindmap/mindmap-canvas.tsx
@@ -495,8 +495,11 @@ function MindmapCanvasInner({
         }
         walk(rootNode)
         if (ids.size > 0) {
+            // One-shot hydration on first non-null rootNode. Only this effect
+            // mutates revealedParentIds from the persisted tree shape, so the
+            // subscription concern of the lint rule doesn't apply.
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setRevealedParentIds(prev => {
-                // 사용자가 이 effect 직전에 토글한 상태가 있을 수 있어 union으로 머지
                 const next = new Set(prev)
                 ids.forEach(id => next.add(id))
                 return next

--- a/lib/d3-layout.ts
+++ b/lib/d3-layout.ts
@@ -56,8 +56,19 @@ export function clearWidthCache(): void {
  * Calculate node width based on label text (internal)
  * Uses character count with different weights for Korean/ASCII
  */
+// 편집 모드 input 너비: min-w-[100px] + 부모 카드 px-4(32) + 버퍼 = 152
+// 빈 라벨 노드는 input이 렌더되므로 이 값을 floor로 사용해야 좌측 레이아웃에서
+// 부모와 겹치지 않음. (X 좌표가 estimatedWidth 기준으로 계산되므로 실제 너비
+// > 추정 너비면 좌측 노드는 부모 쪽으로 침범함.)
+const EDITING_INPUT_WIDTH = 152
+
 function calculateWidth(label: string, isRoot: boolean): number {
     const config = isRoot ? NODE_WIDTH_CONFIG.root : NODE_WIDTH_CONFIG.child
+
+    // 빈 라벨(편집 모드일 가능성 높음): input 렌더 너비를 floor로
+    if (!isRoot && !label.trim()) {
+        return Math.max(config.min, EDITING_INPUT_WIDTH)
+    }
 
     // Count Korean (CJK) vs ASCII characters
     let totalWidth = 0

--- a/stores/mindmap-store.ts
+++ b/stores/mindmap-store.ts
@@ -364,30 +364,29 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
         const { rootNode, currentNode, mindmapId, frameworkId, topic } = get()
         if (!rootNode) return null
 
-        // 새 노드 ID 생성 (UUID 형식)
         const randomPart = Math.random().toString(36).slice(2, 11)
         const newNodeId = `node-${Date.now()}-${randomPart}`
 
-        // 새 노드 객체 생성 (빈 라벨)
+        // 빈 라벨로 생성 + 즉시 편집 모드 진입. 사용자가 아무것도 입력하지
+        // 않고 blur 하면 onBlur 핸들러에서 "새 아이디어"로 자동 채워짐.
         const newNode: MindmapNode = {
             id: newNodeId,
-            label: '',  // 빈 라벨로 생성
+            label: '',
             type: 'manual',
-            children: []
+            children: [],
         }
 
-        // 부모 노드를 찾아서 자식으로 추가
         const addToParent = (node: MindmapNode): MindmapNode => {
             if (node.id === parentId) {
                 return {
                     ...node,
-                    children: [...(node.children || []), newNode]
+                    children: [...(node.children || []), newNode],
                 }
             }
             if (!node.children) return node
             return {
                 ...node,
-                children: node.children.map(addToParent)
+                children: node.children.map(addToParent),
             }
         }
 
@@ -397,7 +396,7 @@ export const useMindmapStore = create<MindmapStore>((set, get) => ({
         set({
             rootNode: updatedRoot,
             currentNode: updatedCurrent,
-            editingNodeId: newNodeId  // 새 노드를 편집 모드로 설정
+            editingNodeId: newNodeId,
         })
         persistTree(mindmapId, updatedRoot, { frameworkId, topic })
 


### PR DESCRIPTION
## Summary

새로고침 후 발생하던 "1클릭 = N개 생성" 버그 근본 원인 규명 + 수동 추가 흐름 재정비 + 노드 시각 디자인 개편.

## 핵심 버그 fix

페이지 새로고침 후 첫 + 클릭 시 숨어있던 자식 노드들이 줄줄이 등장해 "1클릭에 여러 노드 생성"으로 보이던 버그.

**근본 원인:** \`revealedParentIds\`(자식 reveal 여부 추적용 React 로컬 state)는 새로고침 시 빈 Set으로 리셋되지만, 트리 데이터는 localStorage에서 복원됨. → L2+ 자식들이 store에 존재하나 visibleNodes 필터에서 숨겨짐. + 클릭이 부모를 reveal 처리하면서 숨어있던 자식 + 새 노드가 한꺼번에 등장.

**수정:** \`rootNode\` 첫 로드 시 자식 있는 모든 노드 ID를 walk해서 \`revealedParentIds\`에 union ([components/mindmap/mindmap-canvas.tsx](components/mindmap/mindmap-canvas.tsx)).

## 수동 추가(+) UX 재정비

- \`<input>\` → \`contenteditable div\`로 교체. 콘텐츠 너비만큼만 자라고 max-w(280px) 도달 시 줄바꿈, max-h(96px) 도달 시 스크롤. textarea/input의 고정 width 한계 우회.
- + 클릭 → 빈 노드 즉시 생성 + 편집 모드 자동 진입. 사용자가 빈 채로 blur 시 "새 아이디어"로 자동 저장.
- 포커스 안정화: \`nodesFocusable={false}\` (React Flow의 NodeWrapper auto-focus가 contenteditable 가로채던 것 차단) + \`setTimeout(50ms)\`로 React Flow transform 완료 후 focus + 빈 div에 명시적 cursor 배치.
- 더블클릭 편집 제거 — + 버튼과 오작동 잦음. 라벨 수정은 ✏️ Edit 버튼만.

## 노드 디자인

| Level | Style |
|---|---|
| L0 (Root) | slate-800 fill, white text |
| L1 | slate-600 fill, white text |
| L2 | slate-400 fill, white text |
| L3 | slate-300 fill, dark text |
| L4 | slate-200 fill, dark text |
| L5 | 3px border (slate-500) |
| L6 | 2px border |
| L7 | 1.5px border |
| L8+ | 1px border |

- border 노드가 fill 노드보다 커 보이는 문제 → \`inset box-shadow\`로 가짜 테두리 적용해 외곽 사이즈 일치
- display 라벨과 edit contenteditable의 wrap 룰 동기화 (max-w-280, whitespace-pre-wrap, break-words)

## 레벨/모드 변경

- AI 자동 확장 \`MAX_DEPTH = 4 → 7\`로 완화. L8+는 수동 추가만 가능 (soft cap 30)
- 모드 picker 제거. 백엔드 깊이 기반 자동 픽 (L1=mece, L2-3=default, L4+=diverse)
- semantic_type 색상 dot / ⓘ rationale 아이콘 제거. AI description은 노드 라벨 아래 작은 회색 글씨로 노출

## 레이아웃

- 빈 라벨 노드 \`estimatedWidth = 152px\` floor — 좌측 새 노드가 부모와 겹치던 버그 제거 ([lib/d3-layout.ts](lib/d3-layout.ts))

## Test plan

- [ ] + 클릭 → "새 아이디어" 빈 노드 즉시 생성 + 자동 포커스
- [ ] 입력 후 Enter → 라벨 저장 / 빈 채로 blur → "새 아이디어"로 자동 저장 / Esc → 취소
- [ ] 콘텐츠 길이에 따라 노드 가로 → 세로 줄바꿈 (max 280×96)
- [ ] 새로고침 후 + 클릭 → 숨어있던 노드 안 튀어나오고 새 노드 1개만 추가
- [ ] L0-L4 fill, L5-L8+ border 시각 확인 (border가 fill보다 커 보이지 않음)
- [ ] L7 노드까지 AI 확장 가능, L8+는 + 버튼만
- [ ] 좌측 새 노드가 부모와 겹치지 않음
- [ ] 더블클릭으로 편집 진입 안 됨 / ✏️ 버튼은 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)